### PR TITLE
Update CI: Replace Deprecated macos-12 Image and Artifact Action Version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         folder: build/test_coverage/
         single-commit: true
     - name: Save output
-      uses: actions/upload-artifact@v2.2.3
+      uses: actions/upload-artifact@v4.6.0
       with:
         name: test_coverage
         path: build/test_coverage/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         name: test_coverage
         path: build/test_coverage/
   macos:
-    runs-on: macos-12
+    runs-on: macos-14
     strategy:
       matrix:
         config:


### PR DESCRIPTION
# Problem

The CI is currently failing due to the use of a deprecated version of the `macos-12` image and `actions/upload-artifact@v2.2.3`.

# Solution

Updating these components according to GitHub's official recommendations should resolve the CI issues.

# Additional Information

- More details about the deprecated `macos-12` image can be found [here](https://github.com/actions/runner-images/issues/10721).
- Information about `actions/upload-artifact@v2.2.3` is available [here](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/).