### PR TITLE
Implement regular path query algorithm with pathes

### DIFF
--- a/experimental/algorithm/LAGraph_2Rpq.c
+++ b/experimental/algorithm/LAGraph_2Rpq.c
@@ -1,0 +1,770 @@
+//
+// Different RPQ semantics
+//
+
+#define LG_FREE_WORK                            \
+{                                               \
+}
+#define LG_FREE_ALL                         \
+{                                           \
+        LG_FREE_WORK ;                          \
+}
+
+#include "LG_internal.h"
+#include "LAGraphX.h"
+#include <assert.h>
+#include <limits.h>
+
+#define PATH_LIMIT 100000
+
+typedef struct {
+    Path paths[QUICK_PATH_COUNT];
+    size_t path_count;
+    Path *extra_paths;
+} MultiplePaths ;
+
+MultiplePaths multiple_paths_identity ;
+
+void Path_print (const Path *x)
+{
+    if (x->vertex_count == 0)
+    {
+        printf ("empty path \n") ;
+        return ;
+    }
+
+    for (size_t i = 0 ; i < x->vertex_count ; i++)
+    {
+        // Increase the vertex by 1 since usually user expects the same
+        // numbering as in the input determined by MTX file in which the
+        // entries are enumerated starting from 1.
+        printf ("(%ld)", (i < QUICK_PATH_LENGTH ? x->vertices[i] : x->extra_vertices[i - QUICK_PATH_LENGTH]) + 1) ;
+
+        if (i != x->vertex_count - 1)
+        {
+            printf ("-") ;
+        }
+    }
+
+    printf ("\n") ;
+}
+
+static void MultiplePaths_print (const MultiplePaths *x)
+{
+    printf("Multiple paths:\n") ;
+    for (size_t i = 0 ; i < x->path_count ; i++)
+    {
+
+        printf("\t Path %ld: ", i) ;
+        Path_print (&x->paths[i]) ;
+    }
+    printf("\n") ;
+}
+
+GrB_Type multiple_paths ;
+GrB_BinaryOp combine_multiple_paths_op ;
+GrB_Monoid combine_multiple_paths ;
+GrB_BinaryOp first_multiple_paths ;
+GrB_BinaryOp second_multiple_paths ;
+GrB_Semiring first_combine_multiple_paths ;
+GrB_Semiring second_combine_multiple_paths ;
+GrB_IndexUnaryOp extend_multiple_paths ;
+GrB_IndexUnaryOp extend_multiple_simple ;
+GrB_IndexUnaryOp extend_multiple_trails ;
+
+void first_multiple_paths_f(MultiplePaths *z, MultiplePaths *x, bool *_y)
+{
+    *z = *x;
+}
+void second_multiple_paths_f(MultiplePaths *z, bool *_x, MultiplePaths *y)
+{
+    *z = *y;
+}
+
+void combine_multiple_paths_f(MultiplePaths *z, const MultiplePaths *x, const MultiplePaths *y)
+{
+    z->path_count = x->path_count + y->path_count ;
+    assert (z->path_count < QUICK_PATH_COUNT) ;
+
+    for (size_t i = 0 ; i < x->path_count ; i++)
+    {
+        z->paths[i] = x->paths[i] ;
+    }
+
+    for (size_t i = 0 ; i < y->path_count ; i++)
+    {
+        z->paths[x->path_count + i] = y->paths[i] ;
+    }
+
+    // TODO: Support more than QUICK_PATH_COUNT paths.
+}
+
+static inline void path_extend(Path *path, Vertex vertex)
+{
+    if (path->vertex_count == 0)
+    {
+        return ;
+    }
+
+    if (path->vertex_count < QUICK_PATH_LENGTH)
+    {
+        path->vertices[path->vertex_count++] = vertex ;
+    }
+    else
+    {
+        if (path->extra_vertices == NULL)
+        {
+            LG_TRY (LAGraph_Calloc ((void **) &path->extra_vertices, 64, sizeof (Vertex), NULL)) ;
+        }
+        path->extra_vertices [(path->vertex_count++) - QUICK_PATH_LENGTH] = vertex ;
+    }
+
+    // TODO: Support more than QUICK_PATH_LENGTH vertices.
+}
+
+static inline bool path_is_empty(Path *path)
+{
+    return path->vertex_count == 0;
+}
+
+
+static inline void multiple_paths_append(MultiplePaths *multiple_paths, const Path *path)
+{
+    multiple_paths->paths[multiple_paths->path_count++] = *path ;
+
+    // TODO: Support more than QUICK_PATH_COUNT paths.
+}
+
+//
+// ALL PATHS.
+//
+
+// NB: Using this semantic without a length limit makes the code behave like a
+// procedure for searching all paths satisfying the constraints.
+// It means it may not finish if there is loops.
+
+void extend_multiple_paths_f(MultiplePaths *z, const MultiplePaths *x, GrB_Index _row, GrB_Index col, const void *_y)
+{
+    /*if (z != x)
+        for (size_t i = 0 ; i < x->path_count ; i++)
+        {
+            multiple_paths_append(z, &x->paths[i]) ;
+            path_extend (&z->paths[i], col) ;
+        }
+    {*/
+        for (size_t i = 0 ; i < z->path_count ; i++)
+        {
+            Path *path = &z->paths[i] ;
+            path_extend (&z->paths[i], col) ;
+        }
+    //}
+}
+
+//
+// ALL SIMPLE
+//
+
+static inline bool path_extending_will_add_repeated_non_starting_vertex(const Path *path, Vertex vertex)
+{
+    if (path->vertex_count <= 1) 
+    {
+        return false ;
+    }
+
+    for (size_t i = 1 ; i < path->vertex_count ; i++)
+    {
+        if (path->vertices[i] == vertex)
+        {
+            return true ;
+        }
+    }
+
+    Vertex last_vertex = path->vertices[path->vertex_count - 1] ;
+
+    return path->vertices[0] == last_vertex;
+}
+
+void extend_multiple_simple_f(MultiplePaths *z, const MultiplePaths *x, GrB_Index _row, GrB_Index col, const void *_y)
+{
+    /*if (z != x)
+    {
+        for (size_t i = 0 ; i < x->path_count ; i++)
+        {
+            const Path *path = &x->paths[i] ;
+            if (path_has_loop_at_end (path))
+            {
+                continue;
+            }
+
+            multiple_paths_append(z, path) ;
+            path_extend (&z->paths[i], col) ;
+        }
+    }
+    else
+    {*/
+        for (size_t i = 0 ; i < z->path_count ; i++)
+        {
+            Path *path = &z->paths[i] ;
+            if (path_extending_will_add_repeated_non_starting_vertex (path, col))
+            {
+                path->vertex_count = 0 ;
+                continue ;
+            }
+
+            path_extend (&z->paths[i], col) ;
+        }
+    //}
+}
+
+//
+// ALL TRAILS
+//
+
+static inline bool path_extending_will_add_repeated_edge(const Path *path, Vertex vertex_2)
+{
+    if (path->vertex_count == 0)
+    {
+        return false ;
+    }
+
+    // We identify edges as pairs of vertices.
+    Vertex vertex_1 = path->vertices[path->vertex_count - 1] ;
+
+    for (size_t i = 0 ; i < path->vertex_count - 1; i++)
+    {
+        if (path->vertices[i] == vertex_1 && path->vertices[i + 1] == vertex_2)
+        {
+            return true ;
+        }
+    }
+
+    return false ;
+}
+void extend_multiple_trails_f(MultiplePaths *z, const MultiplePaths *x, GrB_Index _row, GrB_Index col, const void *y)
+{
+    /*if (z != x)
+    {
+        z->path_count = x->path_count ;
+
+        for (size_t i = 0 ; i < x->path_count ; i++)
+        {
+            const Path *path = &x->paths[i] ;
+            if (path_extending_will_add_repeated_edge (path, col))
+            {
+                continue ;
+            }
+
+            multiple_paths_append(z, path) ;
+            path_extend (&z->paths[i], col) ;
+        }
+    }
+    else
+    {*/
+        for (size_t i = 0 ; i < z->path_count ; i++)
+        {
+            Path *path = &z->paths[i] ;
+            if (path_extending_will_add_repeated_edge (path, col))
+            {
+                path->vertex_count = 0 ;
+                continue ;
+            }
+
+            path_extend (&z->paths[i], col) ;
+        }
+    //}
+}
+
+#define LG_FREE_WORK                            \
+{                                               \
+    GrB_free (&frontier) ;                      \
+    GrB_free (&next_frontier) ;                 \
+    GrB_free (&symbol_frontier) ;               \
+    GrB_free (&final_reducer) ;                 \
+    LAGraph_Free ((void **) &A, NULL) ;         \
+    LAGraph_Free ((void **) &B, NULL) ;         \
+    LAGraph_Free ((void **) &BT, NULL) ;        \
+}
+
+#define LG_FREE_ALL                         \
+{                                           \
+    LG_FREE_WORK ;                          \
+    LAGraph_Free ((void **) paths, NULL) ;  \
+}
+
+static int LAGraph_2Rpq
+(
+    // output:
+    Path **paths,               // simple paths from one of the starting
+                                // nodes satisfying regular constraints
+    size_t *path_count,         // resulting path count
+    // input:
+    LAGraph_Graph *R,           // input non-deterministic finite automaton
+                                // adjacency matrix decomposition
+    bool *inverse_labels,       // inversed labels
+    size_t nl,                  // total label count, # of matrices graph and
+                                // NFA adjacency matrix decomposition
+    const GrB_Index *QS,        // starting states in NFA
+    size_t nqs,                 // number of starting states in NFA
+    const GrB_Index *QF,        // final states in NFA
+    size_t nqf,                 // number of final states in NFA
+    LAGraph_Graph *G,           // input graph adjacency matrix decomposition
+    const GrB_Index *S,         // source vertices to start searching paths
+    size_t ns,                  // number of source vertices
+    bool inverse,               // inverse the whole query
+    uint64_t limit,             // maximum path count
+    char *msg,                  // LAGraph output message
+    GrB_IndexUnaryOp op         // index unary op for a specific semantic
+)
+{
+    //--------------------------------------------------------------------------
+    // check inputs
+    //--------------------------------------------------------------------------
+
+    LG_CLEAR_MSG ;
+
+    GrB_Matrix frontier = NULL ;         // traversal frontier representing
+                                         // correspondence between NFA states
+                                         // and graph vertices
+    GrB_Matrix symbol_frontier = NULL ;  // part of the new frontier for the
+                                         // specific label
+    GrB_Matrix next_frontier = NULL ;    // frontier value on the next
+                                         // traversal step
+    GrB_Vector final_reducer = NULL ;    // auxiliary vector for reducing the
+                                         // visited matrix to an answer
+
+    GrB_Index ng = 0 ;                   // # nodes in the graph
+    GrB_Index nr = 0 ;                   // # states in the NFA
+    GrB_Index nv = 0 ;                   // # pair count in the frontier
+    GrB_Index states = ns ;              // # pairs in the current
+                                         // correspondence between the graph and
+                                         // the NFA
+
+    GrB_Index rows = 0 ;                 // utility matrix row count
+    GrB_Index cols = 0 ;                 // utility matrix column count
+    GrB_Index vals = 0 ;                 // utility matrix value count
+
+    // TODO: This names might be too short.
+    GrB_Semiring sr1 = first_combine_multiple_paths ;
+    GrB_Semiring sr2 = second_combine_multiple_paths ;
+    GrB_BinaryOp acc = combine_multiple_paths_op ;
+
+    GrB_Matrix *A = NULL ;
+    GrB_Matrix *AT = NULL ;
+    GrB_Matrix *B = NULL ;
+    GrB_Matrix *BT = NULL ;
+
+    LG_ASSERT (paths != NULL, GrB_NULL_POINTER) ;
+    LG_ASSERT (path_count != NULL, GrB_NULL_POINTER) ;
+    LG_ASSERT (G != NULL, GrB_NULL_POINTER) ;
+    LG_ASSERT (R != NULL, GrB_NULL_POINTER) ;
+    LG_ASSERT (S != NULL, GrB_NULL_POINTER) ;
+    LG_ASSERT (op != NULL, GrB_NULL_POINTER) ;
+
+    (*paths) = NULL ;
+    (*path_count) = 0 ;
+
+    for (size_t i = 0 ; i < nl ; i++)
+    {
+        if (G[i] == NULL) continue ;
+        LG_TRY (LAGraph_CheckGraph (G[i], msg)) ;
+    }
+
+    for (size_t i = 0 ; i < nl ; i++)
+    {
+        if (R[i] == NULL) continue ;
+        LG_TRY (LAGraph_CheckGraph (R[i], msg)) ;
+    }
+
+    LG_TRY (LAGraph_Malloc ((void **) &A, nl, sizeof (GrB_Matrix), msg)) ;
+    LG_TRY (LAGraph_Malloc ((void **) &AT, nl, sizeof (GrB_Matrix), msg)) ;
+
+    for (size_t i = 0 ; i < nl ; i++)
+    {
+        if (G[i] == NULL)
+        {
+            A[i] = NULL ;
+            AT[i] = NULL ;
+            continue ;
+        }
+
+        A[i] = G[i]->A ;
+        if (G[i]->kind == LAGraph_ADJACENCY_UNDIRECTED ||
+            G[i]->is_symmetric_structure == LAGraph_TRUE)
+        {
+            AT[i] = A[i] ;
+        }
+        else
+        {
+            // AT[i] could be NULL and the matrix will be transposed by a
+            // descriptor
+            AT[i] = G[i]->AT ;
+        }
+    }
+
+    LG_TRY (LAGraph_Malloc ((void **) &B, nl, sizeof (GrB_Matrix), msg)) ;
+    LG_TRY (LAGraph_Malloc ((void **) &BT, nl, sizeof (GrB_Matrix), msg)) ;
+
+    for (size_t i = 0 ; i < nl ; i++)
+    {
+        BT[i] = NULL ;
+
+        if (R[i] == NULL)
+        {
+            B[i] = NULL ;
+            BT[i] = NULL ;
+            continue ;
+        }
+
+        B[i] = R[i]->A ;
+        if (R[i]->is_symmetric_structure == LAGraph_TRUE)
+        {
+            BT[i] = B[i] ;
+        }
+        else
+        {
+            // BT[i] could be NULL and the matrix will be transposed by a
+            // descriptor
+            BT[i] = R[i]->AT ;
+        }
+    }
+
+    for (size_t i = 0 ; i < nl ; i++)
+    {
+        if (A[i] == NULL) continue ;
+
+        GRB_TRY (GrB_Matrix_nrows (&ng, A[i])) ;
+        break ;
+    }
+
+    for (size_t i = 0 ; i < nl ; i++)
+    {
+        if (B[i] == NULL) continue ;
+
+        GRB_TRY (GrB_Matrix_nrows (&nr, B[i])) ;
+        break ;
+    }
+
+    // Check all the matrices in graph adjacency matrix decomposition are
+    // square and of the same dimensions
+    for (size_t i = 0 ; i < nl ; i++)
+    {
+        if (A[i] == NULL) continue ;
+
+        GRB_TRY (GrB_Matrix_nrows (&rows, A[i])) ;
+        GRB_TRY (GrB_Matrix_ncols (&cols, A[i])) ;
+
+        LG_ASSERT_MSG (rows == ng && cols == ng, LAGRAPH_NOT_CACHED,
+            "all the matrices in the graph adjacency matrix decomposition "
+            "should have the same dimensions and be square") ;
+    }
+
+    // Check all the matrices in NFA adjacency matrix decomposition are
+    // square and of the same dimensions
+    for (size_t i = 0 ; i < nl ; i++)
+    {
+        if (B[i] == NULL) continue ;
+
+        GrB_Index rows = 0 ;
+        GrB_Index cols = 0 ;
+
+        GRB_TRY (GrB_Matrix_nrows (&rows, B[i])) ;
+        GRB_TRY (GrB_Matrix_ncols (&cols, B[i])) ;
+
+        LG_ASSERT_MSG (rows == nr && cols == nr, LAGRAPH_NOT_CACHED,
+            "all the matrices in the NFA adjacency matrix decomposition "
+            "should have the same dimensions and be square") ;
+    }
+
+    // Check source nodes in the graph
+    for (size_t i = 0 ; i < ns ; i++)
+    {
+        GrB_Index s = S [i] ;
+        LG_ASSERT_MSG (s < ng, GrB_INVALID_INDEX, "invalid graph source node") ;
+    }
+
+    // Check starting states of the NFA
+    for (size_t i = 0 ; i < nqs ; i++)
+    {
+        GrB_Index qs = QS [i] ;
+        LG_ASSERT_MSG (qs < nr, GrB_INVALID_INDEX,
+            "invalid NFA starting state") ;
+    }
+
+    // Check final states of the NFA
+    for (size_t i = 0 ; i < nqf ; i++)
+    {
+        GrB_Index qf = QF [i] ;
+        LG_ASSERT_MSG (qf < nr, GrB_INVALID_INDEX, "invalid NFA final state") ;
+    }
+
+    // -------------------------------------------------------------------------
+    // initialization
+    // -------------------------------------------------------------------------
+
+    LG_TRY (LAGraph_Calloc ((void **) paths, PATH_LIMIT, sizeof (Path), msg)) ;
+
+    GRB_TRY (GrB_Vector_new (&final_reducer, GrB_BOOL, nr)) ;
+
+    // Initialize matrix for reducing the result
+    GRB_TRY (GrB_assign (final_reducer, NULL, NULL, true, QF, nqf, NULL)) ;
+
+    GRB_TRY (GrB_Matrix_new (&next_frontier, multiple_paths, nr, ng)) ;
+
+    // Initialize frontier with the source nodes
+
+    for (size_t i = 0 ; i < ns ; i++)
+    {
+        GrB_Index s = S[i] ;
+        MultiplePaths value = {
+            .paths = {
+                {
+                    .vertices = { s },
+                    .vertex_count = 1
+                }
+            },
+            .path_count = 1
+        };
+
+        for (size_t j = 0 ; j < nqs ; j++)
+        {
+            GrB_Index qs = QS[j] ;
+
+            GRB_TRY (GrB_Matrix_setElement_UDT (next_frontier, &value, qs, s)) ;
+        }
+    }
+
+    // Initialize a few utility matrices
+    GRB_TRY (GrB_Matrix_new (&frontier, multiple_paths, nr, ng)) ;
+    GRB_TRY (GrB_Matrix_new (&symbol_frontier, multiple_paths, nr, ng)) ;
+
+    // Main loop
+    while (true)
+    {
+        //printf("Iteration\n");
+        GrB_Index nvals = 0 ;
+        GRB_TRY (GrB_Matrix_nvals (&nvals, next_frontier)) ;
+
+        MultiplePaths *X ;
+        GrB_Index *I ;
+        bool had_non_empty_path = false ;
+
+        //MultiplePaths *X;
+        LG_TRY (LAGraph_Calloc ((void **) &X, nvals, sizeof (MultiplePaths), msg)) ;
+        LG_TRY (LAGraph_Calloc ((void **) &I, nvals, sizeof (GrB_Index), msg)) ;
+
+        // TODO: Change to a generic call.
+        GRB_TRY (GrB_Matrix_extractTuples_UDT (I, GrB_NULL, (void**) X, &nvals, next_frontier)) ;
+        //printf("Next frontier with %d entries\n", nvals);
+
+        for (size_t i = 0 ; i < nvals ; i++)
+        {
+            for (size_t j = 0 ; j < X[i].path_count ; j++)
+            {
+                if (!path_is_empty(&X[i].paths[j]))
+                {
+                    had_non_empty_path = true;
+                    break;
+                }
+            }
+
+            //MultiplePaths_print (&X[i]) ;
+            bool final = false ;
+            for (size_t j = 0 ; j < nqf ; j++)
+            {
+                if (I[i] == QF[j])
+                {
+                    final = true ;
+                    break ;
+                }
+            }
+            //printf("Path at %ld final is %b", I[i], final) ;
+
+            if (!final)
+            {
+                continue ;
+            }
+
+            //printf("Found final paths!\n");
+            for (size_t j = 0 ; j < X[i].path_count && (*path_count) < limit ; j++)
+            {
+                const Path *path = &X[i].paths[j] ;
+                if (!path_is_empty(path))
+                {
+                    (*paths)[(*path_count)++] = *path ;
+                }
+            }
+        }
+
+        if (!had_non_empty_path || (*path_count) == limit)
+        {
+            //printf("breaking\n");
+            break;
+        }
+
+        GrB_Matrix old_frontier = frontier ;
+        frontier = next_frontier ;
+        next_frontier = old_frontier ;
+
+        GRB_TRY (GrB_Matrix_clear(next_frontier)) ;
+
+        // Obtain a new relation between the NFA states and the graph nodes
+        for (size_t i = 0 ; i < nl ; i++)
+        {
+            if (A[i] == NULL || B[i] == NULL) continue ;
+
+            // Traverse the NFA
+            // Try to use a provided transposed matrix or use the descriptor
+            if (!inverse) {
+                if (BT[i] != NULL)
+                {
+                    GRB_TRY (GrB_mxm (symbol_frontier, GrB_NULL, GrB_NULL,
+                        sr2, BT[i], frontier, GrB_DESC_R)) ;
+                }
+                else
+                {
+                    GRB_TRY (GrB_mxm (symbol_frontier, GrB_NULL, GrB_NULL,
+                        sr2, B[i], frontier, GrB_DESC_RT0)) ;
+                }
+            } else {
+                GRB_TRY (GrB_mxm (symbol_frontier, GrB_NULL, GrB_NULL, sr2, B[i], frontier, GrB_DESC_R )) ;
+            }
+
+            // TODO: Skip the iteration if symbol_frontier is already empty.
+
+            // Traverse the graph
+            if (!inverse_labels[i]) {
+                if (!inverse) {
+                    GRB_TRY (GrB_mxm (next_frontier, GrB_NULL, acc, sr1, symbol_frontier, A[i], GrB_NULL)) ;
+                } else if (AT[i]) {
+                    GRB_TRY (GrB_mxm (next_frontier, GrB_NULL, acc, sr1, symbol_frontier, AT[i], GrB_NULL)) ;
+                } else {
+                    GRB_TRY (GrB_mxm (next_frontier, GrB_NULL, acc, sr1, symbol_frontier, A[i], GrB_DESC_T1)) ;
+                }
+            } else {
+                if (!inverse && AT[i]) {
+                    GRB_TRY (GrB_mxm (next_frontier, GrB_NULL, acc, sr1, symbol_frontier, AT[i], GrB_NULL)) ;
+                } else if (!inverse) {
+                    GRB_TRY (GrB_mxm (next_frontier, GrB_NULL, acc, sr1, symbol_frontier, A[i], GrB_DESC_T1)) ;
+                } else {
+                    GRB_TRY (GrB_mxm (next_frontier, GrB_NULL, acc, sr1, symbol_frontier, A[i], GrB_NULL)) ;
+                }
+            }
+        }
+
+        GRB_TRY (GrB_apply (next_frontier, GrB_NULL, GrB_NULL, op, next_frontier, false, GrB_NULL)) ;
+
+    }
+
+    //LG_FREE_WORK ;
+    return (GrB_SUCCESS) ;
+}
+
+
+int LAGraph_2Rpq_AllSimple      // All simple paths satisfying regular
+                                // expression. Simple paths are paths without
+                                // loops or the ones with the same starting
+                                // and final nodes.
+(
+    // output:
+    Path **paths,               // simple paths from one of the starting
+                                // nodes satisfying regular constraints
+    size_t *path_count,         // resulting path count
+    // input:
+    LAGraph_Graph *R,           // input non-deterministic finite automaton
+                                // adjacency matrix decomposition
+    bool *inverse_labels,       // inversed labels
+    size_t nl,                  // total label count, # of matrices graph and
+                                // NFA adjacency matrix decomposition
+    const GrB_Index *QS,        // starting states in NFA
+    size_t nqs,                 // number of starting states in NFA
+    const GrB_Index *QF,        // final states in NFA
+    size_t nqf,                 // number of final states in NFA
+    LAGraph_Graph *G,           // input graph adjacency matrix decomposition
+    const GrB_Index *S,         // source vertices to start searching paths
+    size_t ns,                  // number of source vertices
+    bool inverse,               // inverse the whole query
+    char *msg                   // LAGraph output message
+)
+{
+    return LAGraph_2Rpq(paths, path_count, R, inverse_labels, nl, QS, nqs, QF, nqf, G, S, ns, inverse, ULLONG_MAX, msg, extend_multiple_simple) ;
+}
+
+LAGRAPHX_PUBLIC
+int LAGraph_2Rpq_AllTrails      // All trails satisfying regular expression.
+                                // Trails are paths without repeated edges.
+(
+    // output:
+    Path **paths,                // trails from one of the starting nodes
+                                // satisfying regular constraints
+    size_t *path_count,         // resulting path count
+    // input:
+    LAGraph_Graph *R,           // input non-deterministic finite automaton
+                                // adjacency matrix decomposition
+    bool *inverse_labels,       // inversed labels
+    size_t nl,                  // total label count, # of matrices graph and
+                                // NFA adjacency matrix decomposition
+    const GrB_Index *QS,        // starting states in NFA
+    size_t nqs,                 // number of starting states in NFA
+    const GrB_Index *QF,        // final states in NFA
+    size_t nqf,                 // number of final states in NFA
+    LAGraph_Graph *G,           // input graph adjacency matrix decomposition
+    const GrB_Index *S,         // source vertices to start searching paths
+    size_t ns,                  // number of source vertices
+    bool inverse,               // inverse the whole query
+    char *msg                   // LAGraph output message
+)
+{
+    return LAGraph_2Rpq(paths, path_count, R, inverse_labels, nl, QS, nqs, QF, nqf, G, S, ns, inverse, ULLONG_MAX, msg, extend_multiple_trails) ;
+}
+
+int LAGraph_2Rpq_AllPaths       // All paths satisfying regular expression
+(
+    // output:
+    Path **paths,               // paths from one of the starting nodes
+                                // satisfying regular constraints
+    size_t *path_count,         // resulting path count
+                                // input:
+    LAGraph_Graph *R,           // input non-deterministic finite automaton
+                                // adjacency matrix decomposition
+    bool *inverse_labels,       // inversed labels
+    size_t nl,                  // total label count, # of matrices graph and
+                                // NFA adjacency matrix decomposition
+    const GrB_Index *QS,        // starting states in NFA
+    size_t nqs,                 // number of starting states in NFA
+    const GrB_Index *QF,        // final states in NFA
+    size_t nqf,                 // number of final states in NFA
+    LAGraph_Graph *G,           // input graph adjacency matrix decomposition
+    const GrB_Index *S,         // source vertices to start searching paths
+    size_t ns,                  // number of source vertices
+    bool inverse,               // inverse the whole query
+    uint64_t limit,             // maximum path count
+    char *msg                   // LAGraph output message
+    )
+{
+        return LAGraph_2Rpq(paths, path_count, R, inverse_labels, nl, QS, nqs, QF, nqf, G, S, ns, inverse, limit, msg, extend_multiple_paths) ;
+}
+
+#define LG_FREE_WORK                            \
+{                                               \
+}
+#define LG_FREE_ALL                         \
+{                                           \
+        LG_FREE_WORK ;                          \
+}
+
+int LAGraph_Rpq_initialize(char *msg)
+{
+        GRB_TRY (GrB_Type_new (&multiple_paths, sizeof(MultiplePaths))) ;
+
+        GRB_TRY (GrB_BinaryOp_new (&combine_multiple_paths_op, (GxB_binary_function) &combine_multiple_paths_f, multiple_paths, multiple_paths, multiple_paths)) ;
+        GRB_TRY (GrB_BinaryOp_new (&first_multiple_paths, (GxB_binary_function) &first_multiple_paths_f, multiple_paths, multiple_paths, GrB_BOOL)) ;
+        GRB_TRY (GrB_BinaryOp_new (&second_multiple_paths, (GxB_binary_function) &second_multiple_paths_f, multiple_paths, GrB_BOOL, multiple_paths)) ;
+        GRB_TRY (GrB_Monoid_new (&combine_multiple_paths, combine_multiple_paths_op, (void*) &multiple_paths_identity)) ;
+
+        GRB_TRY (GrB_Semiring_new (&first_combine_multiple_paths, combine_multiple_paths, first_multiple_paths)) ;
+        GRB_TRY (GrB_Semiring_new (&second_combine_multiple_paths, combine_multiple_paths, second_multiple_paths)) ;
+
+        GRB_TRY (GrB_IndexUnaryOp_new (&extend_multiple_paths, (GxB_index_unary_function) &extend_multiple_paths_f, multiple_paths, multiple_paths, GrB_BOOL)) ;
+        GRB_TRY (GrB_IndexUnaryOp_new (&extend_multiple_simple, (GxB_index_unary_function) &extend_multiple_simple_f, multiple_paths, multiple_paths, GrB_BOOL)) ;
+        GRB_TRY (GrB_IndexUnaryOp_new (&extend_multiple_trails, (GxB_index_unary_function) &extend_multiple_trails_f, multiple_paths, multiple_paths, GrB_BOOL)) ;
+}

--- a/experimental/algorithm/LAGraph_2Rpq.c
+++ b/experimental/algorithm/LAGraph_2Rpq.c
@@ -21,14 +21,20 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define PATH_LIMIT 100000
 
+#define RPQ_MAX_PATH_LENGTH 60000
+
+#define RPQ_STRINGIFY_HELPER(x) #x
+#define RPQ_STRINGIFY(x) RPQ_STRINGIFY_HELPER(x)
+
 // This define and three functions below need for YAGO dataset.
 // Because we have OOM on it
 // 
-#define PATHS_PER_POINT_LIMIT 15000
+#define PATHS_PER_POINT_LIMIT 3000000
 
 static atomic_int path_limit_exceeded ;
 
@@ -153,9 +159,6 @@ static size_t temp_arena_used (void)
 // JIT kernels are compiled into a separate shared object. They cannot call
 // static functions from this translation unit, so expose tiny wrappers for
 // the stateful parts: arena allocation and path-limit reporting.
-//
-// These functions must be visible from the dynamic symbol table. If LAGraphX
-// builds with hidden visibility, LAGRAPHX_PUBLIC is important here.
 LAGRAPHX_PUBLIC
 void *LAGraph_Rpq_jit_temp_calloc_bytes (size_t size)
 {
@@ -202,9 +205,10 @@ GrB_IndexUnaryOp extend_multiple_trails ;
 "#include <stddef.h>\n"                                                \
 "#include <stdbool.h>\n"                                               \
 "#include <string.h>\n"                                                \
-"#define QUICK_PATH_LENGTH 20\n"                                       \
-"#define QUICK_PATH_COUNT 1\n"                                         \
-"#define PATHS_PER_POINT_LIMIT 15000\n"                                \
+"#define QUICK_PATH_LENGTH " RPQ_STRINGIFY(QUICK_PATH_LENGTH) "\n"     \
+"#define QUICK_PATH_COUNT " RPQ_STRINGIFY(QUICK_PATH_COUNT) "\n"       \
+"#define PATHS_PER_POINT_LIMIT " RPQ_STRINGIFY(PATHS_PER_POINT_LIMIT) "\n"\
+"#define RPQ_MAX_PATH_LENGTH " RPQ_STRINGIFY(RPQ_MAX_PATH_LENGTH) "\n" \
 "typedef uint64_t Vertex;\n"                                           \
 "typedef struct PathExtra {\n"                                         \
 "    size_t len;\n"                                                    \
@@ -252,6 +256,11 @@ GrB_IndexUnaryOp extend_multiple_trails ;
 "{\n"                                                                  \
 "    return path->vertex_count > 1 &&\n"                                \
 "        path_start_vertex_jit(path) == path_last_vertex_jit(path);\n"  \
+"}\n"                                                                  \
+"static bool all_paths_can_extend_jit(const Path *path)\n"             \
+"{\n"                                                                  \
+"    return RPQ_MAX_PATH_LENGTH == 0 ||\n"                              \
+"        path->vertex_count < RPQ_MAX_PATH_LENGTH;\n"                   \
 "}\n"                                                                  \
 "static PathExtra *path_extra_temp_alloc_copy_plus_one_jit(\n"          \
 "    const Path *src, Vertex vertex)\n"                                 \
@@ -364,13 +373,12 @@ GrB_IndexUnaryOp extend_multiple_trails ;
 "    *multiple_paths_nth_mut_jit(x, x->path_count) = *path;\n"          \
 "    x->path_count++;\n"                                                \
 "}\n"                                                                  \
-"static bool path_extending_will_add_repeated_non_starting_vertex_jit(\n"\
+"static bool path_extending_will_add_repeated_vertex_jit(\n"            \
 "    const Path *path, Vertex vertex)\n"                                \
 "{\n"                                                                  \
 "    if (path->vertex_count == 0) return false;\n"                      \
 "    if (path_is_closed_cycle_jit(path)) return true;\n"                \
-"    if (vertex == path_start_vertex_jit(path)) return false;\n"        \
-"    for (size_t i = 1; i < path->vertex_count; i++)\n"                 \
+"    for (size_t i = 0 ; i < path->vertex_count ; i++)\n"                 \
 "    {\n"                                                              \
 "        if (path_get_vertex_jit(path, i) == vertex) return true;\n"    \
 "    }\n"                                                              \
@@ -440,6 +448,7 @@ GrB_IndexUnaryOp extend_multiple_trails ;
 "    for (size_t i = 0; i < src.path_count; i++)\n"                     \
 "    {\n"                                                              \
 "        Path path = *multiple_paths_nth_const_jit(&src, i);\n"        \
+"        if (!all_paths_can_extend_jit(&path)) continue;\n"            \
 "        path_extend_jit(&path, (Vertex) col);\n"                      \
 "        if (!path_is_empty_jit(&path))\n"                              \
 "        {\n"                                                          \
@@ -460,7 +469,7 @@ GrB_IndexUnaryOp extend_multiple_trails ;
 "    for (size_t i = 0; i < src.path_count; i++)\n"                     \
 "    {\n"                                                              \
 "        Path path = *multiple_paths_nth_const_jit(&src, i);\n"        \
-"        if (path_extending_will_add_repeated_non_starting_vertex_jit(\n"\
+"        if (path_extending_will_add_repeated_vertex_jit(\n"            \
 "            &path, (Vertex) col))\n"                                   \
 "        {\n"                                                          \
 "            continue;\n"                                               \
@@ -543,6 +552,12 @@ static bool path_is_closed_cycle (const Path *path)
 {
     return path->vertex_count > 1 &&
         path_start_vertex (path) == path_last_vertex (path) ;
+}
+
+static bool all_paths_can_extend (const Path *path)
+{
+    return RPQ_MAX_PATH_LENGTH == 0 ||
+        path->vertex_count < RPQ_MAX_PATH_LENGTH ;
 }
 
 static PathExtra *path_extra_temp_alloc_copy_plus_one
@@ -809,18 +824,6 @@ static void multiple_paths_append_unchecked (MultiplePaths *x, const Path *path)
 }
 //
 
-static void MultiplePaths_print (const MultiplePaths *x)
-{
-    printf("Multiple paths:\n") ;
-    for (size_t i = 0 ; i < x->path_count ; i++)
-    {
-
-        printf("\t Path %zu: ", i) ;
-        Path_print (multiple_paths_nth_const (x, i)) ;
-    }
-    printf("\n") ;
-}
-
 // All functions below reworked.
 // Due to graphblas api, we must handle z param like it's empty.
 // It should just store result (z = f(x)).
@@ -882,6 +885,11 @@ void extend_multiple_paths_f(MultiplePaths *z, const MultiplePaths *x, GrB_Index
     for (size_t i = 0 ; i < src.path_count ; i++)
     {
         Path path = *multiple_paths_nth_const (&src, i) ;
+        if (!all_paths_can_extend (&path))
+        {
+            continue ;
+        }
+
         path_extend (&path, (Vertex) col) ;
 
         if (!path_is_empty (&path))
@@ -895,7 +903,9 @@ void extend_multiple_paths_f(MultiplePaths *z, const MultiplePaths *x, GrB_Index
 // ALL SIMPLE
 //
 
-static inline bool path_extending_will_add_repeated_non_starting_vertex(const Path *path, Vertex vertex)
+
+// remove cycle support from all simple
+static inline bool path_extending_will_add_repeated_vertex(const Path *path, Vertex vertex)
 {
     if (path->vertex_count == 0)
     {
@@ -907,12 +917,7 @@ static inline bool path_extending_will_add_repeated_non_starting_vertex(const Pa
         return true ;
     }
 
-    if (vertex == path_start_vertex (path))
-    {
-        return false ;
-    }
-
-    for (size_t i = 1 ; i < path->vertex_count ; i++)
+    for (size_t i = 0 ; i < path->vertex_count ; i++)
     {
         if (path_get_vertex (path, i) == vertex)
         {
@@ -939,7 +944,7 @@ void extend_multiple_simple_f(MultiplePaths *z, const MultiplePaths *x, GrB_Inde
     {
         Path path = *multiple_paths_nth_const (&src, i) ;
 
-        if (path_extending_will_add_repeated_non_starting_vertex (&path,
+        if (path_extending_will_add_repeated_vertex (&path,
             (Vertex) col))
         {
             continue ;
@@ -1067,13 +1072,52 @@ static int ensure_result_capacity
     return GrB_SUCCESS ;
 }
 
+static int final_state_was_visited
+(
+    GrB_Matrix visited,
+    const GrB_Index *QF,
+    size_t nqf,
+    GrB_Index vertex,
+    bool *seen
+)
+{
+    GrB_Info info ;
+    bool value ;
 
+    *seen = false ;
+
+    for (size_t i = 0 ; i < nqf ; i++)
+    {
+        value = false ;
+        info = GrB_Matrix_extractElement_BOOL (&value, visited, QF [i],
+            vertex) ;
+        if (info == GrB_NO_VALUE)
+        {
+            continue ;
+        }
+        if (info != GrB_SUCCESS)
+        {
+            return info ;
+        }
+        if (value)
+        {
+            *seen = true ;
+            return GrB_SUCCESS ;
+        }
+    }
+
+    return GrB_SUCCESS ;
+}
+
+
+#undef LG_FREE_WORK
+#undef LG_FREE_ALL
 #define LG_FREE_WORK                            \
 {                                               \
     GrB_free (&frontier) ;                      \
     GrB_free (&next_frontier) ;                 \
     GrB_free (&symbol_frontier) ;               \
-    GrB_free (&final_reducer) ;                 \
+    GrB_free (&visited) ;                       \
     LAGraph_Free ((void **) &A, NULL) ;         \
     LAGraph_Free ((void **) &AT, NULL) ;        \
     LAGraph_Free ((void **) &B, NULL) ;         \
@@ -1132,8 +1176,6 @@ static int LAGraph_2Rpq
     GrB_Matrix next_frontier = NULL ;    // frontier value on the next
                                          // traversal step
     GrB_Matrix visited = NULL ;          // visited pairs (state, vertex)
-    GrB_Vector final_reducer = NULL ;    // auxiliary vector for reducing the
-                                         // visited matrix to an answer
 
     GrB_Index ng = 0 ;                   // # nodes in the graph
     GrB_Index nr = 0 ;                   // # states in the NFA
@@ -1166,6 +1208,9 @@ static int LAGraph_2Rpq
     (*path_count) = 0 ;
 
     path_limit_reset () ;
+
+    LG_ASSERT_MSG (!ignore_visited || ns == 1, GrB_INVALID_VALUE,
+        "AllShortestPaths requires exactly one source vertex") ;
 
     // init arenas for pathExtra
     LG_TRY (temp_arena_init (msg)) ;
@@ -1308,13 +1353,9 @@ static int LAGraph_2Rpq
     // initialization
     // -------------------------------------------------------------------------
 
-    GRB_TRY (LAGraph_Calloc ((void **) paths, PATH_LIMIT, sizeof (Path), msg)) ;
+    GRB_TRY (LAGraph_Calloc ((void **) paths, PATH_LIMIT,
+        sizeof (Path), msg)) ;
     result_capacity = PATH_LIMIT ;
-
-    GRB_TRY (GrB_Vector_new (&final_reducer, GrB_BOOL, nr)) ;
-
-    // Initialize matrix for reducing the result
-    GRB_TRY (GrB_assign (final_reducer, NULL, NULL, true, QF, nqf, NULL)) ;
 
     GRB_TRY (GrB_Matrix_new (&next_frontier, multiple_paths, nr, ng)) ;
 
@@ -1348,11 +1389,6 @@ static int LAGraph_2Rpq
         }
     }
 
-    if (ignore_visited)
-    {
-        GrB_assign (visited, NULL, NULL, true, QS, nqs, S, ns, NULL) ;
-    }
-
     // Initialize a few utility matrices
     GRB_TRY (GrB_Matrix_new (&frontier, multiple_paths, nr, ng)) ;
     GRB_TRY (GrB_Matrix_new (&symbol_frontier, multiple_paths, nr, ng)) ;
@@ -1360,7 +1396,6 @@ static int LAGraph_2Rpq
     // Main loop
     while (true)
     {
-        //printf("Iteration\n");
         GrB_Index nvals = 0 ;
         bool had_non_empty_path = false ;
 
@@ -1368,25 +1403,31 @@ static int LAGraph_2Rpq
 
         LG_TRY (LAGraph_Calloc ((void **) &X, nvals, sizeof (MultiplePaths), msg)) ;
         LG_TRY (LAGraph_Calloc ((void **) &I, nvals, sizeof (GrB_Index), msg)) ;
-        LG_TRY (LAGraph_Calloc ((void **) &J, nvals, sizeof (GrB_Index), msg)) ;
+        if (ignore_visited)
+        {
+            LG_TRY (LAGraph_Calloc ((void **) &J, nvals,
+                sizeof (GrB_Index), msg)) ;
+        }
 
         // TODO: Change to a generic call.
-        GRB_TRY (GrB_Matrix_extractTuples_UDT (I, J, (void**) X, &nvals, next_frontier)) ;
-        //printf("Next frontier with %d entries\n", nvals);
+        GRB_TRY (GrB_Matrix_extractTuples_UDT (I,
+            ignore_visited ? J : GrB_NULL, (void**) X, &nvals,
+            next_frontier)) ;
 
         for (size_t i = 0 ; i < nvals ; i++)
         {
             for (size_t j = 0 ; j < X[i].path_count ; j++)
             {
+                const Path *path = multiple_paths_nth_const (&X[i], j) ;
+
                 // Required beacause we need to handle not only quick paths
-                if (!path_is_empty (multiple_paths_nth_const (&X[i], j)))
+                if (!path_is_empty (path))
                 {
                     had_non_empty_path = true;
                     break;
                 }
             }
 
-            //MultiplePaths_print (&X[i]) ;
             bool final = false ;
             for (size_t j = 0 ; j < nqf ; j++)
             {
@@ -1396,34 +1437,36 @@ static int LAGraph_2Rpq
                     break ;
                 }
             }
-            //printf("Path at %ld final is %b", I[i], final) ;
-
-            // HACK: only for all_shortest_paths
-            if (ignore_visited) {
-                GrB_Vector w;
-                GRB_TRY (GrB_Vector_new (&w, GrB_BOOL, nr)) ;
-                GrB_Col_extract(w, GrB_NULL, GrB_NULL, visited, QF, nqf, J[i], GrB_NULL);
-                GrB_Index col_nvals = 0 ;
-                GrB_Vector_nvals (&col_nvals, w) ;
-                GrB_free (&w) ;
-
-                if (col_nvals > 0) {
-                    continue ;
-                }
-            }
 
             if (!final)
             {
                 continue ;
             }
 
-            //printf("Found final paths!\n");
+            if (ignore_visited)
+            {
+                bool seen_final = false ;
+
+                GRB_TRY (final_state_was_visited (visited, QF, nqf, J [i],
+                    &seen_final)) ;
+                if (seen_final)
+                {
+                    continue ;
+                }
+            }
+
             if ((*path_count) >= limit)
             {
                 continue ;
             }
 
-            size_t result_need = (*path_count) + X[i].path_count ;
+            uint64_t remaining_limit = limit - (uint64_t) (*path_count) ;
+            size_t paths_to_reserve = X[i].path_count ;
+            if (remaining_limit < (uint64_t) paths_to_reserve)
+            {
+                paths_to_reserve = (size_t) remaining_limit ;
+            }
+            size_t result_need = (*path_count) + paths_to_reserve ;
             if (result_need > result_capacity)
             {
                 LG_TRY (ensure_result_capacity (paths, &result_capacity,
@@ -1445,9 +1488,8 @@ static int LAGraph_2Rpq
 
         if (ignore_visited)
         {
-            //GRB_TRY (GrB_assign (visited, visited, GrB_NULL, next_frontier,
-            //    GrB_ALL, nr, GrB_ALL, ng, GrB_DESC_SC)) ;
-            GrB_assign (visited, next_frontier, GrB_NULL, true, GrB_ALL, nr, GrB_ALL, ng, GrB_DESC_S) ;
+            GRB_TRY (GrB_assign (visited, next_frontier, GrB_NULL, true,
+                GrB_ALL, nr, GrB_ALL, ng, GrB_DESC_S)) ;
         }
 
         LAGraph_Free ((void **) &X, NULL) ;
@@ -1456,7 +1498,6 @@ static int LAGraph_2Rpq
 
         if (!had_non_empty_path || (*path_count) == limit)
         {
-            //printf("breaking\n");
             break;
         }
 
@@ -1493,25 +1534,28 @@ static int LAGraph_2Rpq
             GRB_TRY (GrB_Matrix_nvals (&symbol_nvals, symbol_frontier)) ;
             if (symbol_nvals == 0) continue ;
 
-            GrB_Descriptor desc_forward = ignore_visited ? GrB_DESC_SC : GrB_NULL ;
-            GrB_Descriptor desc_backward = ignore_visited ? GrB_DESC_SCT1 : GrB_DESC_T1 ;
+            GrB_Matrix mask = ignore_visited ? visited : GrB_NULL ;
+            GrB_Descriptor desc_forward = ignore_visited ? GrB_DESC_SC :
+                GrB_NULL ;
+            GrB_Descriptor desc_backward = ignore_visited ? GrB_DESC_SCT1 :
+                GrB_DESC_T1 ;
 
             // Traverse the graph
             if (!inverse_labels[i]) {
                 if (!inverse) {
-                    GRB_TRY (GrB_mxm (next_frontier, visited, acc, sr1, symbol_frontier, A[i], desc_forward)) ;
+                    GRB_TRY (GrB_mxm (next_frontier, mask, acc, sr1, symbol_frontier, A[i], desc_forward)) ;
                 } else if (AT[i]) {
-                    GRB_TRY (GrB_mxm (next_frontier, visited, acc, sr1, symbol_frontier, AT[i], desc_forward)) ;
+                    GRB_TRY (GrB_mxm (next_frontier, mask, acc, sr1, symbol_frontier, AT[i], desc_forward)) ;
                 } else {
-                    GRB_TRY (GrB_mxm (next_frontier, visited, acc, sr1, symbol_frontier, A[i], desc_backward)) ;
+                    GRB_TRY (GrB_mxm (next_frontier, mask, acc, sr1, symbol_frontier, A[i], desc_backward)) ;
                 }
             } else {
                 if (!inverse && AT[i]) {
-                    GRB_TRY (GrB_mxm (next_frontier, visited, acc, sr1, symbol_frontier, AT[i], desc_forward)) ;
+                    GRB_TRY (GrB_mxm (next_frontier, mask, acc, sr1, symbol_frontier, AT[i], desc_forward)) ;
                 } else if (!inverse) {
-                    GRB_TRY (GrB_mxm (next_frontier, visited, acc, sr1, symbol_frontier, A[i], desc_backward)) ;
+                    GRB_TRY (GrB_mxm (next_frontier, mask, acc, sr1, symbol_frontier, A[i], desc_backward)) ;
                 } else {
-                    GRB_TRY (GrB_mxm (next_frontier, visited, acc, sr1, symbol_frontier, A[i], desc_forward)) ;
+                    GRB_TRY (GrB_mxm (next_frontier, mask, acc, sr1, symbol_frontier, A[i], desc_forward)) ;
                 }
             }
 
@@ -1519,8 +1563,13 @@ static int LAGraph_2Rpq
             LG_ASSERT_MSGF (!temp_alloc_failed (), GrB_OUT_OF_MEMORY,
                 "out of memory in temporary RPQ allocator: used=%zu capacity=%zu",
                 temp_arena_used (), temp_arena_capacity) ;
-            LG_ASSERT_MSG (!path_limit_failed (), GrB_OUT_OF_MEMORY,
-                "path limit per point exceeded") ;
+            if (path_limit_failed ())
+            {
+                LG_ERROR_MSG ("LAGraph failure (file %s, line %d): %s",
+                    __FILE__, __LINE__, "path limit per point exceeded") ;
+                LG_FREE_WORK ;
+                return GrB_OUT_OF_MEMORY ;
+            }
         }
 
         GRB_TRY (GrB_apply (next_frontier, GrB_NULL, GrB_NULL, op, next_frontier, false, GrB_NULL)) ;
@@ -1529,8 +1578,13 @@ static int LAGraph_2Rpq
         LG_ASSERT_MSGF (!temp_alloc_failed (), GrB_OUT_OF_MEMORY,
             "out of memory in temporary RPQ allocator: used=%zu capacity=%zu",
             temp_arena_used (), temp_arena_capacity) ;
-        LG_ASSERT_MSG (!path_limit_failed (), GrB_OUT_OF_MEMORY,
-            "path limit per point exceeded") ;
+        if (path_limit_failed ())
+        {
+            LG_ERROR_MSG ("LAGraph failure (file %s, line %d): %s",
+                __FILE__, __LINE__, "path limit per point exceeded") ;
+            LG_FREE_WORK ;
+            return GrB_OUT_OF_MEMORY ;
+        }
     }
 
     LG_FREE_WORK ;
@@ -1540,8 +1594,7 @@ static int LAGraph_2Rpq
 
 int LAGraph_2Rpq_AllSimple      // All simple paths satisfying regular
                                 // expression. Simple paths are paths without
-                                // loops or the ones with the same starting
-                                // and final nodes.
+                                // repeated vertices.
 (
     // output:
     Path **paths,               // simple paths from one of the starting
@@ -1642,10 +1695,11 @@ int LAGraph_2Rpq_AllShortestPaths       // All shortest paths satisfying regular
     const GrB_Index *S,         // source vertices to start searching paths
     size_t ns,                  // number of source vertices
     bool inverse,               // inverse the whole query
+    uint64_t limit,             // maximum path count
     char *msg                   // LAGraph output message
     )
 {
-        return LAGraph_2Rpq(paths, path_count, R, inverse_labels, nl, QS, nqs, QF, nqf, G, S, ns, inverse, true, ULLONG_MAX, msg, extend_multiple_paths) ;
+        return LAGraph_2Rpq(paths, path_count, R, inverse_labels, nl, QS, nqs, QF, nqf, G, S, ns, inverse, true, limit, msg, extend_multiple_paths) ;
 }
 
 // Required because returned Path objects may own heap-allocated PathExtra.
@@ -1662,6 +1716,8 @@ int LAGraph_2Rpq_FreePaths
     return GrB_SUCCESS ;
 }
 
+#undef LG_FREE_WORK
+#undef LG_FREE_ALL
 #define LG_FREE_WORK                            \
 {                                               \
 }

--- a/experimental/algorithm/LAGraph_2Rpq.c
+++ b/experimental/algorithm/LAGraph_2Rpq.c
@@ -12,37 +12,162 @@
 
 #include "LG_internal.h"
 #include "LAGraphX.h"
+
 #include <assert.h>
 #include <limits.h>
 
-
-#define MAX_MEM (1 * 1024 * 1024 * 1024)
-
-const char memory_arena[MAX_MEM];
-size_t cntr = 0;
-bool oom = false;
-void *xalloc(size_t size) {
-    assert(size % sizeof(int64_t) == 0);
-    if (cntr + size > MAX_MEM) {
-        // OOM: loop back to the beggining and flag the answer as wrong.
-        oom = true;
-        cntr = 0;
-    }
-
-    void *ptr = (void*) &(memory_arena[cntr]);
-    cntr += size;
-    return ptr;
-}
-void xfree(void) {
-#ifdef NDEBUG
-    printf("2RPQ arena allocator stats: allocated=%llu memory_limit=%llu\n", cntr, MAX_MEM);
-#endif
-    oom = false;
-    cntr = 0;
-}
-
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
 
 #define PATH_LIMIT 100000
+
+// This define and three functions below need for YAGO dataset.
+// Because we have OOM on it
+// 
+#define PATHS_PER_POINT_LIMIT 15000
+
+static atomic_int path_limit_exceeded ;
+
+static void path_limit_reset (void)
+{
+    atomic_store (&path_limit_exceeded, 0) ;
+}
+
+static void path_limit_mark_exceeded (void)
+{
+    atomic_store (&path_limit_exceeded, 1) ;
+}
+
+static bool path_limit_failed (void)
+{
+    return atomic_load (&path_limit_exceeded) != 0 ;
+}
+//
+
+// Temporary storage for data referenced by GraphBLAS UDT values.
+// GraphBLAS copies MultiplePaths by value, so pointers inside it must point to
+// memory that remains alive while frontier matrices are alive.
+#define TEMP_ARENA_BYTES ((size_t) 32 * 1024 * 1024 * 1024)
+
+static unsigned char *temp_arena_data = NULL ;
+static size_t temp_arena_capacity = 0 ;
+static atomic_size_t temp_arena_offset ;
+static atomic_int temp_arena_oom ;
+
+static size_t align_up_size (size_t value, size_t align)
+{
+    size_t rem = value % align ;
+
+    if (rem == 0)
+    {
+        return value ;
+    }
+
+    return value + (align - rem) ;
+}
+
+static int temp_arena_init (char *msg)
+{
+    int info ;
+
+    temp_arena_data = NULL ;
+    temp_arena_capacity = 0 ;
+    atomic_store (&temp_arena_offset, 0) ;
+    atomic_store (&temp_arena_oom, 0) ;
+
+    info = LAGraph_Malloc ((void **) &temp_arena_data,
+        TEMP_ARENA_BYTES, sizeof (unsigned char), msg) ;
+    if (info != GrB_SUCCESS)
+    {
+        atomic_store (&temp_arena_oom, 1) ;
+        return info ;
+    }
+
+    temp_arena_capacity = TEMP_ARENA_BYTES ;
+    return GrB_SUCCESS ;
+}
+
+static void temp_arena_destroy (void)
+{
+    LAGraph_Free ((void **) &temp_arena_data, NULL) ;
+    temp_arena_capacity = 0 ;
+    atomic_store (&temp_arena_offset, 0) ;
+    atomic_store (&temp_arena_oom, 0) ;
+}
+
+static void *temp_alloc (size_t size)
+{
+    size_t align ;
+    size_t aligned_size ;
+    size_t start ;
+
+    if (size == 0)
+    {
+        return NULL ;
+    }
+
+    align = _Alignof (max_align_t) ;
+    aligned_size = align_up_size (size, align) ;
+    start = atomic_fetch_add (&temp_arena_offset, aligned_size) ;
+
+    if (start > temp_arena_capacity ||
+        aligned_size > temp_arena_capacity - start)
+    {
+        atomic_store (&temp_arena_oom, 1) ;
+        return NULL ;
+    }
+
+    return (void *) (temp_arena_data + start) ;
+}
+
+static void *temp_calloc_bytes (size_t size)
+{
+    void *ptr ;
+
+    ptr = temp_alloc (size) ;
+    if (ptr != NULL)
+    {
+        memset (ptr, 0, size) ;
+    }
+
+    return ptr ;
+}
+
+static bool temp_alloc_failed (void)
+{
+    return atomic_load (&temp_arena_oom) != 0 ;
+}
+
+static size_t temp_arena_used (void)
+{
+    return atomic_load (&temp_arena_offset) ;
+}
+//
+
+
+
+// JIT kernels are compiled into a separate shared object. They cannot call
+// static functions from this translation unit, so expose tiny wrappers for
+// the stateful parts: arena allocation and path-limit reporting.
+//
+// These functions must be visible from the dynamic symbol table. If LAGraphX
+// builds with hidden visibility, LAGRAPHX_PUBLIC is important here.
+LAGRAPHX_PUBLIC
+void *LAGraph_Rpq_jit_temp_calloc_bytes (size_t size)
+{
+    return temp_calloc_bytes (size) ;
+}
+
+LAGRAPHX_PUBLIC
+void LAGraph_Rpq_jit_path_limit_mark_exceeded (void)
+{
+    path_limit_mark_exceeded () ;
+}
+//
 
 typedef struct MultiplePathsExtra {
     size_t count;
@@ -57,6 +182,488 @@ typedef struct {
 
 MultiplePaths multiple_paths_identity ;
 
+GrB_Type multiple_paths ;
+GrB_BinaryOp combine_multiple_paths_op ;
+GrB_Monoid combine_multiple_paths ;
+GrB_BinaryOp first_multiple_paths ;
+GrB_BinaryOp second_multiple_paths ;
+GrB_Semiring first_combine_multiple_paths ;
+GrB_Semiring second_combine_multiple_paths ;
+GrB_IndexUnaryOp extend_multiple_paths ;
+GrB_IndexUnaryOp extend_multiple_simple ;
+GrB_IndexUnaryOp extend_multiple_trails ;
+
+
+
+
+// JIT definitions
+#define MULTIPLE_PATHS_TYPE_DEFN                                      \
+"#include <stdint.h>\n"                                                \
+"#include <stddef.h>\n"                                                \
+"#include <stdbool.h>\n"                                               \
+"#include <string.h>\n"                                                \
+"#define QUICK_PATH_LENGTH 20\n"                                       \
+"#define QUICK_PATH_COUNT 1\n"                                         \
+"#define PATHS_PER_POINT_LIMIT 15000\n"                                \
+"typedef uint64_t Vertex;\n"                                           \
+"typedef struct PathExtra {\n"                                         \
+"    size_t len;\n"                                                    \
+"    Vertex vertices[];\n"                                             \
+"} PathExtra;\n"                                                       \
+"typedef struct Path {\n"                                              \
+"    Vertex vertices[QUICK_PATH_LENGTH];\n"                            \
+"    size_t vertex_count;\n"                                           \
+"    PathExtra *extra;\n"                                              \
+"} Path;\n"                                                           \
+"typedef struct MultiplePathsExtra {\n"                                \
+"    size_t count;\n"                                                  \
+"    Path paths[];\n"                                                  \
+"} MultiplePathsExtra;\n"                                              \
+"typedef struct MultiplePaths {\n"                                     \
+"    Path paths[QUICK_PATH_COUNT];\n"                                  \
+"    size_t path_count;\n"                                             \
+"    MultiplePathsExtra *extra;\n"                                     \
+"} MultiplePaths;\n"                                                   \
+"extern void *LAGraph_Rpq_jit_temp_calloc_bytes(size_t size);\n"        \
+"extern void LAGraph_Rpq_jit_path_limit_mark_exceeded(void);\n"         \
+"static size_t path_extra_len_jit(const Path *path)\n"                 \
+"{\n"                                                                  \
+"    return path->vertex_count > QUICK_PATH_LENGTH ?\n"                \
+"        path->vertex_count - QUICK_PATH_LENGTH : 0;\n"                \
+"}\n"                                                                  \
+"static Vertex path_get_vertex_jit(const Path *path, size_t i)\n"       \
+"{\n"                                                                  \
+"    if (i < QUICK_PATH_LENGTH) return path->vertices[i];\n"            \
+"    return path->extra->vertices[i - QUICK_PATH_LENGTH];\n"           \
+"}\n"                                                                  \
+"static bool path_is_empty_jit(const Path *path)\n"                    \
+"{\n"                                                                  \
+"    return path->vertex_count == 0;\n"                                 \
+"}\n"                                                                  \
+"static Vertex path_start_vertex_jit(const Path *path)\n"              \
+"{\n"                                                                  \
+"    return path_get_vertex_jit(path, 0);\n"                            \
+"}\n"                                                                  \
+"static Vertex path_last_vertex_jit(const Path *path)\n"               \
+"{\n"                                                                  \
+"    return path_get_vertex_jit(path, path->vertex_count - 1);\n"       \
+"}\n"                                                                  \
+"static bool path_is_closed_cycle_jit(const Path *path)\n"             \
+"{\n"                                                                  \
+"    return path->vertex_count > 1 &&\n"                                \
+"        path_start_vertex_jit(path) == path_last_vertex_jit(path);\n"  \
+"}\n"                                                                  \
+"static PathExtra *path_extra_temp_alloc_copy_plus_one_jit(\n"          \
+"    const Path *src, Vertex vertex)\n"                                 \
+"{\n"                                                                  \
+"    size_t old_extra_len = path_extra_len_jit(src);\n"                 \
+"    size_t new_extra_len = old_extra_len + 1;\n"                       \
+"    size_t nbytes = sizeof(PathExtra) +\n"                             \
+"        new_extra_len * sizeof(Vertex);\n"                             \
+"    PathExtra *extra = (PathExtra *)\n"                                \
+"        LAGraph_Rpq_jit_temp_calloc_bytes(nbytes);\n"                  \
+"    if (extra == NULL) return NULL;\n"                                  \
+"    extra->len = new_extra_len;\n"                                     \
+"    if (old_extra_len > 0)\n"                                          \
+"    {\n"                                                              \
+"        memcpy(extra->vertices, src->extra->vertices,\n"               \
+"            old_extra_len * sizeof(Vertex));\n"                        \
+"    }\n"                                                              \
+"    extra->vertices[old_extra_len] = vertex;\n"                        \
+"    return extra;\n"                                                   \
+"}\n"                                                                  \
+"static void path_extend_jit(Path *path, Vertex vertex)\n"              \
+"{\n"                                                                  \
+"    if (path->vertex_count == 0) return;\n"                            \
+"    if (path->vertex_count < QUICK_PATH_LENGTH)\n"                     \
+"    {\n"                                                              \
+"        path->vertices[path->vertex_count] = vertex;\n"                \
+"        path->vertex_count++;\n"                                       \
+"        return;\n"                                                     \
+"    }\n"                                                              \
+"    PathExtra *new_extra =\n"                                          \
+"        path_extra_temp_alloc_copy_plus_one_jit(path, vertex);\n"      \
+"    if (new_extra == NULL)\n"                                          \
+"    {\n"                                                              \
+"        path->vertex_count = 0;\n"                                     \
+"        path->extra = NULL;\n"                                         \
+"        return;\n"                                                     \
+"    }\n"                                                              \
+"    path->extra = new_extra;\n"                                        \
+"    path->vertex_count++;\n"                                           \
+"}\n"                                                                  \
+"static size_t multiple_paths_capacity_jit(const MultiplePaths *x)\n"   \
+"{\n"                                                                  \
+"    size_t cap = QUICK_PATH_COUNT;\n"                                  \
+"    if (x->extra != NULL) cap += x->extra->count;\n"                  \
+"    return cap;\n"                                                     \
+"}\n"                                                                  \
+"static const Path *multiple_paths_nth_const_jit(\n"                   \
+"    const MultiplePaths *x, size_t j)\n"                               \
+"{\n"                                                                  \
+"    if (j < QUICK_PATH_COUNT) return &x->paths[j];\n"                  \
+"    return &x->extra->paths[j - QUICK_PATH_COUNT];\n"                  \
+"}\n"                                                                  \
+"static Path *multiple_paths_nth_mut_jit(MultiplePaths *x, size_t j)\n" \
+"{\n"                                                                  \
+"    if (j < QUICK_PATH_COUNT) return &x->paths[j];\n"                  \
+"    return &x->extra->paths[j - QUICK_PATH_COUNT];\n"                  \
+"}\n"                                                                  \
+"static MultiplePathsExtra *multiple_paths_extra_temp_alloc_jit(\n"     \
+"    size_t extra_count)\n"                                             \
+"{\n"                                                                  \
+"    if (extra_count == 0) return NULL;\n"                              \
+"    size_t nbytes = sizeof(MultiplePathsExtra) +\n"                    \
+"        extra_count * sizeof(Path);\n"                                  \
+"    MultiplePathsExtra *extra = (MultiplePathsExtra *)\n"              \
+"        LAGraph_Rpq_jit_temp_calloc_bytes(nbytes);\n"                  \
+"    if (extra == NULL) return NULL;\n"                                  \
+"    extra->count = extra_count;\n"                                     \
+"    return extra;\n"                                                   \
+"}\n"                                                                  \
+"static bool multiple_paths_prepare_jit(MultiplePaths *x,\n"            \
+"    size_t capacity)\n"                                                \
+"{\n"                                                                  \
+"    memset(x, 0, sizeof(*x));\n"                                       \
+"    if (capacity > PATHS_PER_POINT_LIMIT)\n"                           \
+"    {\n"                                                              \
+"        LAGraph_Rpq_jit_path_limit_mark_exceeded();\n"                 \
+"        return false;\n"                                               \
+"    }\n"                                                              \
+"    if (capacity > QUICK_PATH_COUNT)\n"                                \
+"    {\n"                                                              \
+"        x->extra = multiple_paths_extra_temp_alloc_jit(\n"             \
+"            capacity - QUICK_PATH_COUNT);\n"                           \
+"        if (x->extra == NULL)\n"                                       \
+"        {\n"                                                          \
+"            x->path_count = 0;\n"                                      \
+"            return false;\n"                                           \
+"        }\n"                                                          \
+"    }\n"                                                              \
+"    return true;\n"                                                    \
+"}\n"                                                                  \
+"static bool multiple_paths_append_jit(MultiplePaths *x,\n"             \
+"    const Path *path)\n"                                               \
+"{\n"                                                                  \
+"    if (x->path_count >= PATHS_PER_POINT_LIMIT)\n"                     \
+"    {\n"                                                              \
+"        LAGraph_Rpq_jit_path_limit_mark_exceeded();\n"                 \
+"        return false;\n"                                               \
+"    }\n"                                                              \
+"    if (x->path_count >= multiple_paths_capacity_jit(x))\n"            \
+"    {\n"                                                              \
+"        return false;\n"                                               \
+"    }\n"                                                              \
+"    *multiple_paths_nth_mut_jit(x, x->path_count) = *path;\n"          \
+"    x->path_count++;\n"                                                \
+"    return true;\n"                                                    \
+"}\n"                                                                  \
+"static void multiple_paths_append_unchecked_jit(MultiplePaths *x,\n"   \
+"    const Path *path)\n"                                               \
+"{\n"                                                                  \
+"    *multiple_paths_nth_mut_jit(x, x->path_count) = *path;\n"          \
+"    x->path_count++;\n"                                                \
+"}\n"                                                                  \
+"static bool path_extending_will_add_repeated_non_starting_vertex_jit(\n"\
+"    const Path *path, Vertex vertex)\n"                                \
+"{\n"                                                                  \
+"    if (path->vertex_count == 0) return false;\n"                      \
+"    if (path_is_closed_cycle_jit(path)) return true;\n"                \
+"    if (vertex == path_start_vertex_jit(path)) return false;\n"        \
+"    for (size_t i = 1; i < path->vertex_count; i++)\n"                 \
+"    {\n"                                                              \
+"        if (path_get_vertex_jit(path, i) == vertex) return true;\n"    \
+"    }\n"                                                              \
+"    return false;\n"                                                   \
+"}\n"                                                                  \
+"static bool path_extending_will_add_repeated_edge_jit(\n"              \
+"    const Path *path, Vertex vertex_2)\n"                              \
+"{\n"                                                                  \
+"    if (path->vertex_count == 0) return false;\n"                      \
+"    Vertex vertex_1 = path_last_vertex_jit(path);\n"                   \
+"    for (size_t i = 0; i + 1 < path->vertex_count; i++)\n"             \
+"    {\n"                                                              \
+"        if (path_get_vertex_jit(path, i) == vertex_1 &&\n"             \
+"            path_get_vertex_jit(path, i + 1) == vertex_2)\n"           \
+"        {\n"                                                          \
+"            return true;\n"                                            \
+"        }\n"                                                          \
+"    }\n"                                                              \
+"    return false;\n"                                                   \
+"}\n"
+
+#define FIRST_MULTIPLE_PATHS_DEFN                                      \
+"void first_multiple_paths_f(MultiplePaths *z, MultiplePaths *x,\n"     \
+"    bool *_y)\n"                                                       \
+"{\n"                                                                  \
+"    (void) _y;\n"                                                      \
+"    *z = *x;\n"                                                        \
+"}\n"
+
+#define SECOND_MULTIPLE_PATHS_DEFN                                     \
+"void second_multiple_paths_f(MultiplePaths *z, bool *_x,\n"           \
+"    MultiplePaths *y)\n"                                               \
+"{\n"                                                                  \
+"    (void) _x;\n"                                                      \
+"    *z = *y;\n"                                                        \
+"}\n"
+
+#define COMBINE_MULTIPLE_PATHS_DEFN                                    \
+"void combine_multiple_paths_f(MultiplePaths *z,\n"                    \
+"    const MultiplePaths *x, const MultiplePaths *y)\n"                 \
+"{\n"                                                                  \
+"    MultiplePaths x_copy = *x;\n"                                      \
+"    MultiplePaths y_copy = *y;\n"                                      \
+"    size_t path_count = x_copy.path_count + y_copy.path_count;\n"      \
+"    if (!multiple_paths_prepare_jit(z, path_count)) return;\n"         \
+"    for (size_t j = 0; j < x_copy.path_count; j++)\n"                  \
+"    {\n"                                                              \
+"        multiple_paths_append_unchecked_jit(z,\n"                     \
+"            multiple_paths_nth_const_jit(&x_copy, j));\n"             \
+"    }\n"                                                              \
+"    for (size_t j = 0; j < y_copy.path_count; j++)\n"                  \
+"    {\n"                                                              \
+"        multiple_paths_append_unchecked_jit(z,\n"                     \
+"            multiple_paths_nth_const_jit(&y_copy, j));\n"             \
+"    }\n"                                                              \
+"}\n"
+
+#define EXTEND_MULTIPLE_PATHS_DEFN                                     \
+"void extend_multiple_paths_f(MultiplePaths *z,\n"                     \
+"    const MultiplePaths *x, GrB_Index _row, GrB_Index col,\n"          \
+"    const void *_y)\n"                                                 \
+"{\n"                                                                  \
+"    MultiplePaths src = *x;\n"                                         \
+"    (void) _row;\n"                                                    \
+"    (void) _y;\n"                                                      \
+"    if (!multiple_paths_prepare_jit(z, src.path_count)) return;\n"     \
+"    for (size_t i = 0; i < src.path_count; i++)\n"                     \
+"    {\n"                                                              \
+"        Path path = *multiple_paths_nth_const_jit(&src, i);\n"        \
+"        path_extend_jit(&path, (Vertex) col);\n"                      \
+"        if (!path_is_empty_jit(&path))\n"                              \
+"        {\n"                                                          \
+"            multiple_paths_append_unchecked_jit(z, &path);\n"         \
+"        }\n"                                                          \
+"    }\n"                                                              \
+"}\n"
+
+#define EXTEND_MULTIPLE_SIMPLE_DEFN                                    \
+"void extend_multiple_simple_f(MultiplePaths *z,\n"                    \
+"    const MultiplePaths *x, GrB_Index _row, GrB_Index col,\n"          \
+"    const void *_y)\n"                                                 \
+"{\n"                                                                  \
+"    MultiplePaths src = *x;\n"                                         \
+"    (void) _row;\n"                                                    \
+"    (void) _y;\n"                                                      \
+"    if (!multiple_paths_prepare_jit(z, src.path_count)) return;\n"     \
+"    for (size_t i = 0; i < src.path_count; i++)\n"                     \
+"    {\n"                                                              \
+"        Path path = *multiple_paths_nth_const_jit(&src, i);\n"        \
+"        if (path_extending_will_add_repeated_non_starting_vertex_jit(\n"\
+"            &path, (Vertex) col))\n"                                   \
+"        {\n"                                                          \
+"            continue;\n"                                               \
+"        }\n"                                                          \
+"        path_extend_jit(&path, (Vertex) col);\n"                      \
+"        if (!path_is_empty_jit(&path))\n"                              \
+"        {\n"                                                          \
+"            multiple_paths_append_unchecked_jit(z, &path);\n"         \
+"        }\n"                                                          \
+"    }\n"                                                              \
+"}\n"
+
+#define EXTEND_MULTIPLE_TRAILS_DEFN                                    \
+"void extend_multiple_trails_f(MultiplePaths *z,\n"                    \
+"    const MultiplePaths *x, GrB_Index _row, GrB_Index col,\n"          \
+"    const void *y)\n"                                                  \
+"{\n"                                                                  \
+"    MultiplePaths src = *x;\n"                                         \
+"    (void) _row;\n"                                                    \
+"    (void) y;\n"                                                       \
+"    if (!multiple_paths_prepare_jit(z, src.path_count)) return;\n"     \
+"    for (size_t i = 0; i < src.path_count; i++)\n"                     \
+"    {\n"                                                              \
+"        Path path = *multiple_paths_nth_const_jit(&src, i);\n"        \
+"        if (path_extending_will_add_repeated_edge_jit(&path,\n"        \
+"            (Vertex) col))\n"                                          \
+"        {\n"                                                          \
+"            continue;\n"                                               \
+"        }\n"                                                          \
+"        path_extend_jit(&path, (Vertex) col);\n"                      \
+"        if (!path_is_empty_jit(&path))\n"                              \
+"        {\n"                                                          \
+"            multiple_paths_append_unchecked_jit(z, &path);\n"         \
+"        }\n"                                                          \
+"    }\n"                                                              \
+"}\n"
+//
+
+// Helpers for Path with inline vertices + heap/temp overflow vertices.
+static size_t path_extra_len (const Path *path)
+{
+    if (path->vertex_count > QUICK_PATH_LENGTH)
+    {
+        return path->vertex_count - QUICK_PATH_LENGTH ;
+    }
+
+    return 0 ;
+}
+
+static Vertex path_get_vertex (const Path *path, size_t i)
+{
+    assert (path != NULL) ;
+    assert (i < path->vertex_count) ;
+
+    if (i < QUICK_PATH_LENGTH)
+    {
+        return path->vertices[i] ;
+    }
+
+    assert (path->extra != NULL) ;
+    return path->extra->vertices[i - QUICK_PATH_LENGTH] ;
+}
+
+static bool path_is_empty (const Path *path)
+{
+    return path->vertex_count == 0 ;
+}
+
+static Vertex path_start_vertex (const Path *path)
+{
+    return path_get_vertex (path, 0) ;
+}
+
+static Vertex path_last_vertex (const Path *path)
+{
+    return path_get_vertex (path, path->vertex_count - 1) ;
+}
+
+static bool path_is_closed_cycle (const Path *path)
+{
+    return path->vertex_count > 1 &&
+        path_start_vertex (path) == path_last_vertex (path) ;
+}
+
+static PathExtra *path_extra_temp_alloc_copy_plus_one
+(
+    const Path *src,
+    Vertex vertex
+)
+{
+    size_t old_extra_len ;
+    size_t new_extra_len ;
+    size_t nbytes ;
+    PathExtra *extra ;
+
+    old_extra_len = path_extra_len (src) ;
+    new_extra_len = old_extra_len + 1 ;
+    nbytes = sizeof (PathExtra) + new_extra_len * sizeof (Vertex) ;
+
+    extra = (PathExtra *) temp_calloc_bytes (nbytes) ;
+    if (extra == NULL)
+    {
+        return NULL ;
+    }
+
+    extra->len = new_extra_len ;
+
+    if (old_extra_len > 0)
+    {
+        assert (src->extra != NULL) ;
+        memcpy (extra->vertices, src->extra->vertices,
+            old_extra_len * sizeof (Vertex)) ;
+    }
+
+    extra->vertices[old_extra_len] = vertex ;
+    return extra ;
+}
+
+static void path_extend (Path *path, Vertex vertex)
+{
+    PathExtra *new_extra ;
+
+    if (path->vertex_count == 0)
+    {
+        return ;
+    }
+
+    if (path->vertex_count < QUICK_PATH_LENGTH)
+    {
+        path->vertices[path->vertex_count] = vertex ;
+        path->vertex_count++ ;
+        return ;
+    }
+
+    new_extra = path_extra_temp_alloc_copy_plus_one (path, vertex) ;
+    if (new_extra == NULL)
+    {
+        path->vertex_count = 0 ;
+        path->extra = NULL ;
+        return ;
+    }
+
+    path->extra = new_extra ;
+    path->vertex_count++ ;
+}
+
+static int path_clone_heap (Path *dst, const Path *src, char *msg)
+{
+    size_t extra_len ;
+    size_t nbytes ;
+    int info ;
+
+    memset (dst, 0, sizeof (*dst)) ;
+    dst->vertex_count = src->vertex_count ;
+    memcpy (dst->vertices, src->vertices, sizeof (dst->vertices)) ;
+
+    extra_len = path_extra_len (src) ;
+    if (extra_len == 0)
+    {
+        dst->extra = NULL ;
+        return GrB_SUCCESS ;
+    }
+
+    nbytes = sizeof (PathExtra) + extra_len * sizeof (Vertex) ;
+    info = LAGraph_Malloc ((void **) &dst->extra, nbytes, sizeof (char), msg) ;
+    if (info != GrB_SUCCESS)
+    {
+        return info ;
+    }
+
+    dst->extra->len = extra_len ;
+    memcpy (dst->extra->vertices, src->extra->vertices,
+        extra_len * sizeof (Vertex)) ;
+    return GrB_SUCCESS ;
+}
+
+static void path_destroy_heap (Path *path)
+{
+    if (path == NULL)
+    {
+        return ;
+    }
+
+    LAGraph_Free ((void **) &path->extra, NULL) ;
+    path->vertex_count = 0 ;
+}
+
+static void free_all (Path **paths, size_t path_count)
+{
+    if (paths == NULL || *paths == NULL)
+    {
+        return ;
+    }
+
+    for (size_t i = 0 ; i < path_count ; i++)
+    {
+        path_destroy_heap (&((*paths)[i])) ;
+    }
+
+    LAGraph_Free ((void **) paths, NULL) ;
+}
+//
+
 void Path_print (const Path *x)
 {
     if (x->vertex_count == 0)
@@ -70,7 +677,7 @@ void Path_print (const Path *x)
         // Increase the vertex by 1 since usually user expects the same
         // numbering as in the input determined by MTX file in which the
         // entries are enumerated starting from 1.
-        printf ("(%llu)", (i < QUICK_PATH_LENGTH ? x->vertices[i] : x->extra->vertices[i - QUICK_PATH_LENGTH]) + 1) ;
+        printf ("(%llu)", (unsigned long long) (path_get_vertex (x, i) + 1)) ;
 
         if (i != x->vertex_count - 1)
         {
@@ -81,133 +688,175 @@ void Path_print (const Path *x)
     printf ("\n") ;
 }
 
+// Block with helper function for handling cases
+// when we have more paths than QUICK_PATH_COUNT
+static size_t multiple_paths_capacity (const MultiplePaths *x)
+{
+    size_t cap = QUICK_PATH_COUNT ;
+
+    if (x->extra != NULL)
+    {
+        cap += x->extra->count ;
+    }
+
+    return cap ;
+}
+
+static const Path *multiple_paths_nth_const
+(
+    const MultiplePaths *x,
+    size_t j
+)
+{
+    assert (j < x->path_count) ;
+
+    if (j < QUICK_PATH_COUNT)
+    {
+        return &x->paths[j] ;
+    }
+
+    assert (x->extra != NULL) ;
+    return &x->extra->paths[j - QUICK_PATH_COUNT] ;
+}
+
+static Path *multiple_paths_nth_mut
+(
+    MultiplePaths *x,
+    size_t j
+)
+{
+    assert (j < multiple_paths_capacity (x)) ;
+
+    if (j < QUICK_PATH_COUNT)
+    {
+        return &x->paths[j] ;
+    }
+
+    assert (x->extra != NULL) ;
+    return &x->extra->paths[j - QUICK_PATH_COUNT] ;
+}
+
+static MultiplePathsExtra *multiple_paths_extra_temp_alloc (size_t extra_count)
+{
+    size_t nbytes ;
+    MultiplePathsExtra *extra ;
+
+    if (extra_count == 0)
+    {
+        return NULL ;
+    }
+
+    nbytes = sizeof (MultiplePathsExtra) + extra_count * sizeof (Path) ;
+    extra = (MultiplePathsExtra *) temp_calloc_bytes (nbytes) ;
+    if (extra == NULL)
+    {
+        return NULL ;
+    }
+
+    extra->count = extra_count ;
+    return extra ;
+}
+
+static bool multiple_paths_prepare (MultiplePaths *x, size_t capacity)
+{
+    memset (x, 0, sizeof (*x)) ;
+
+    // Preserve the per-point path cap. If one frontier cell
+    // would contain too many paths, GraphBLAS UDF cannot return an error
+    // directly, so we mark a global flag and check it after GrB_mxm/GrB_apply.
+    if (capacity > PATHS_PER_POINT_LIMIT)
+    {
+        path_limit_mark_exceeded () ;
+        return false ;
+    }
+
+    if (capacity > QUICK_PATH_COUNT)
+    {
+        x->extra = multiple_paths_extra_temp_alloc (capacity - QUICK_PATH_COUNT) ;
+        if (x->extra == NULL)
+        {
+            x->path_count = 0 ;
+            return false ;
+        }
+    }
+
+    return true ;
+}
+
+static bool multiple_paths_append (MultiplePaths *x, const Path *path)
+{
+    // handle per-point cap
+    if (x->path_count >= PATHS_PER_POINT_LIMIT)
+    {
+        path_limit_mark_exceeded () ;
+        return false ;
+    }
+
+    if (x->path_count >= multiple_paths_capacity (x))
+    {
+        return false ;
+    }
+
+    *multiple_paths_nth_mut (x, x->path_count) = *path ;
+    x->path_count++ ;
+    return true ;
+}
+
+static void multiple_paths_append_unchecked (MultiplePaths *x, const Path *path)
+{
+    *multiple_paths_nth_mut (x, x->path_count) = *path ;
+    x->path_count++ ;
+}
+//
+
 static void MultiplePaths_print (const MultiplePaths *x)
 {
     printf("Multiple paths:\n") ;
     for (size_t i = 0 ; i < x->path_count ; i++)
     {
 
-        printf("\t Path %ld: ", i) ;
-        Path_print (&x->paths[i]) ;
+        printf("\t Path %zu: ", i) ;
+        Path_print (multiple_paths_nth_const (x, i)) ;
     }
     printf("\n") ;
 }
 
-GrB_Type multiple_paths ;
-GrB_BinaryOp combine_multiple_paths_op ;
-GrB_Monoid combine_multiple_paths ;
-GrB_BinaryOp first_multiple_paths ;
-GrB_BinaryOp second_multiple_paths ;
-GrB_Semiring first_combine_multiple_paths ;
-GrB_Semiring second_combine_multiple_paths ;
-GrB_IndexUnaryOp extend_multiple_paths ;
-GrB_IndexUnaryOp extend_multiple_simple ;
-GrB_IndexUnaryOp extend_multiple_trails ;
-
+// All functions below reworked.
+// Due to graphblas api, we must handle z param like it's empty.
+// It should just store result (z = f(x)).
+// So we can't use it for any checks, or use its fields for something.
 void first_multiple_paths_f(MultiplePaths *z, MultiplePaths *x, bool *_y)
 {
-    *z = *x;
+    (void) _y ;
+    *z = *x ;
 }
+
 void second_multiple_paths_f(MultiplePaths *z, bool *_x, MultiplePaths *y)
 {
-    *z = *y;
+    (void) _x ;
+    *z = *y ;
 }
-
-static inline MultiplePathsExtra *multiple_paths_extra_alloc(size_t count) {
-    MultiplePathsExtra *extra = xalloc(sizeof(MultiplePathsExtra) + count * sizeof(Path));
-    extra->count = count;
-    return extra;
-}
-
-#define nth_path(x, j) (((j) < QUICK_PATH_COUNT) ? ((x)->paths[j]) : ((x)->extra->paths[j - QUICK_PATH_COUNT]))
-#define set_nth_path(x, j, v) \
-    do { \
-        if (j < QUICK_PATH_COUNT) { \
-            x->paths[j] = v; \
-        } else { \
-            x->extra->paths[j - QUICK_PATH_COUNT] = v; \
-        } \
-    } while (0)
 
 void combine_multiple_paths_f(MultiplePaths *z, const MultiplePaths *x, const MultiplePaths *y)
 {
-    size_t path_count = x->path_count + y->path_count ;
-    z->path_count = path_count ;
+    MultiplePaths x_copy = *x ;
+    MultiplePaths y_copy = *y ;
+    size_t path_count = x_copy.path_count + y_copy.path_count ;
 
-
-    if (path_count <= QUICK_PATH_COUNT) {
-        size_t i = 0;
-        for (size_t j = 0 ; j < x->path_count ; j++)
-        {
-            z->paths[i++] = x->paths[j] ;
-        }
-
-        for (size_t j = 0 ; j < y->path_count ; j++)
-        {
-            z->paths[i++] = y->paths[j] ;
-        }
-        return;
-    } else {
-        MultiplePathsExtra *extra = multiple_paths_extra_alloc (path_count - QUICK_PATH_COUNT);
-        z->extra = extra;
-
-        size_t i = 0;
-        for (size_t j = 0 ; j < x->path_count ; j++)
-        {
-            Path path = nth_path(x, j);
-            set_nth_path(z, i, path);
-            i++;
-        }
-
-        for (size_t j = 0 ; j < y->path_count ; j++)
-        {
-            Path path = nth_path(y, j) ;
-            set_nth_path(z, i, path);
-            i++;
-        }
-    }
-
-
-
-    // TODO: Support more than QUICK_PATH_COUNT paths.
-}
-
-
-static inline void path_extend(Path *path, Vertex vertex)
-{
-    if (path->vertex_count == 0)
+    if (!multiple_paths_prepare (z, path_count))
     {
         return ;
     }
 
-    if (path->vertex_count < QUICK_PATH_LENGTH)
+    for (size_t j = 0 ; j < x_copy.path_count ; j++)
     {
-        path->vertices[path->vertex_count++] = vertex ;
-    }
-    else
-    {
-        if (path->extra == NULL)
-        {
-            LAGraph_Calloc ((void **) &path->extra, 64, sizeof (Vertex), NULL) ;
-        }
-
-        path->extra->vertices [(path->vertex_count++) - QUICK_PATH_LENGTH] = vertex ;
+        multiple_paths_append_unchecked (z, multiple_paths_nth_const (&x_copy, j)) ;
     }
 
-    // TODO: Support more than QUICK_PATH_LENGTH vertices.
-}
-
-static inline bool path_is_empty(Path *path)
-{
-    return path->vertex_count == 0;
-}
-
-
-static inline void multiple_paths_append(MultiplePaths *multiple_paths, const Path *path)
-{
-    multiple_paths->paths[multiple_paths->path_count++] = *path ;
-
-    // TODO: Support more than QUICK_PATH_COUNT paths.
+    for (size_t j = 0 ; j < y_copy.path_count ; j++)
+    {
+        multiple_paths_append_unchecked (z, multiple_paths_nth_const (&y_copy, j)) ;
+    }
 }
 
 //
@@ -220,19 +869,26 @@ static inline void multiple_paths_append(MultiplePaths *multiple_paths, const Pa
 
 void extend_multiple_paths_f(MultiplePaths *z, const MultiplePaths *x, GrB_Index _row, GrB_Index col, const void *_y)
 {
-    /*if (z != x)
-        for (size_t i = 0 ; i < x->path_count ; i++)
+    MultiplePaths src = *x ;
+
+    (void) _row ;
+    (void) _y ;
+
+    if (!multiple_paths_prepare (z, src.path_count))
+    {
+        return ;
+    }
+
+    for (size_t i = 0 ; i < src.path_count ; i++)
+    {
+        Path path = *multiple_paths_nth_const (&src, i) ;
+        path_extend (&path, (Vertex) col) ;
+
+        if (!path_is_empty (&path))
         {
-            multiple_paths_append(z, &x->paths[i]) ;
-            path_extend (&z->paths[i], col) ;
+            multiple_paths_append_unchecked (z, &path) ;
         }
-    {*/
-        for (size_t i = 0 ; i < z->path_count ; i++)
-        {
-            Path *path = &z->paths[i] ;
-            path_extend (&z->paths[i], col) ;
-        }
-    //}
+    }
 }
 
 //
@@ -241,54 +897,60 @@ void extend_multiple_paths_f(MultiplePaths *z, const MultiplePaths *x, GrB_Index
 
 static inline bool path_extending_will_add_repeated_non_starting_vertex(const Path *path, Vertex vertex)
 {
-    if (path->vertex_count <= 1) 
+    if (path->vertex_count == 0)
+    {
+        return false ;
+    }
+
+    if (path_is_closed_cycle (path))
+    {
+        return true ;
+    }
+
+    if (vertex == path_start_vertex (path))
     {
         return false ;
     }
 
     for (size_t i = 1 ; i < path->vertex_count ; i++)
     {
-        if (path->vertices[i] == vertex)
+        if (path_get_vertex (path, i) == vertex)
         {
             return true ;
         }
     }
 
-    Vertex last_vertex = path->vertices[path->vertex_count - 1] ;
-
-    return path->vertices[0] == last_vertex;
+    return false ;
 }
 
 void extend_multiple_simple_f(MultiplePaths *z, const MultiplePaths *x, GrB_Index _row, GrB_Index col, const void *_y)
 {
-    /*if (z != x)
-    {
-        for (size_t i = 0 ; i < x->path_count ; i++)
-        {
-            const Path *path = &x->paths[i] ;
-            if (path_has_loop_at_end (path))
-            {
-                continue;
-            }
+    MultiplePaths src = *x ;
 
-            multiple_paths_append(z, path) ;
-            path_extend (&z->paths[i], col) ;
+    (void) _row ;
+    (void) _y ;
+
+    if (!multiple_paths_prepare (z, src.path_count))
+    {
+        return ;
+    }
+
+    for (size_t i = 0 ; i < src.path_count ; i++)
+    {
+        Path path = *multiple_paths_nth_const (&src, i) ;
+
+        if (path_extending_will_add_repeated_non_starting_vertex (&path,
+            (Vertex) col))
+        {
+            continue ;
+        }
+
+        path_extend (&path, (Vertex) col) ;
+        if (!path_is_empty (&path))
+        {
+            multiple_paths_append_unchecked (z, &path) ;
         }
     }
-    else
-    {*/
-        for (size_t i = 0 ; i < z->path_count ; i++)
-        {
-            Path *path = &z->paths[i] ;
-            if (path_extending_will_add_repeated_non_starting_vertex (path, col))
-            {
-                path->vertex_count = 0 ;
-                continue ;
-            }
-
-            path_extend (&z->paths[i], col) ;
-        }
-    //}
 }
 
 //
@@ -303,11 +965,12 @@ static inline bool path_extending_will_add_repeated_edge(const Path *path, Verte
     }
 
     // We identify edges as pairs of vertices.
-    Vertex vertex_1 = path->vertices[path->vertex_count - 1] ;
+    Vertex vertex_1 = path_last_vertex (path) ;
 
-    for (size_t i = 0 ; i < path->vertex_count - 1; i++)
+    for (size_t i = 0 ; i + 1 < path->vertex_count ; i++)
     {
-        if (path->vertices[i] == vertex_1 && path->vertices[i + 1] == vertex_2)
+        if (path_get_vertex (path, i) == vertex_1 &&
+            path_get_vertex (path, i + 1) == vertex_2)
         {
             return true ;
         }
@@ -315,39 +978,95 @@ static inline bool path_extending_will_add_repeated_edge(const Path *path, Verte
 
     return false ;
 }
+
 void extend_multiple_trails_f(MultiplePaths *z, const MultiplePaths *x, GrB_Index _row, GrB_Index col, const void *y)
 {
-    /*if (z != x)
+    MultiplePaths src = *x ;
+
+    (void) _row ;
+    (void) y ;
+
+    if (!multiple_paths_prepare (z, src.path_count))
     {
-        z->path_count = x->path_count ;
+        return ;
+    }
 
-        for (size_t i = 0 ; i < x->path_count ; i++)
+    for (size_t i = 0 ; i < src.path_count ; i++)
+    {
+        Path path = *multiple_paths_nth_const (&src, i) ;
+
+        if (path_extending_will_add_repeated_edge (&path, (Vertex) col))
         {
-            const Path *path = &x->paths[i] ;
-            if (path_extending_will_add_repeated_edge (path, col))
-            {
-                continue ;
-            }
+            continue ;
+        }
 
-            multiple_paths_append(z, path) ;
-            path_extend (&z->paths[i], col) ;
+        path_extend (&path, (Vertex) col) ;
+        if (!path_is_empty (&path))
+        {
+            multiple_paths_append_unchecked (z, &path) ;
         }
     }
-    else
-    {*/
-        for (size_t i = 0 ; i < z->path_count ; i++)
-        {
-            Path *path = &z->paths[i] ;
-            if (path_extending_will_add_repeated_edge (path, col))
-            {
-                path->vertex_count = 0 ;
-                continue ;
-            }
-
-            path_extend (&z->paths[i], col) ;
-        }
-    //}
 }
+
+// Result array can grow past PATH_LIMIT if the caller passes a larger limit.
+static int ensure_result_capacity
+(
+    Path **paths,
+    size_t *capacity,
+    size_t need,
+    char *msg
+)
+{
+    Path *new_paths ;
+    size_t new_capacity ;
+    int info ;
+
+    if (need <= *capacity)
+    {
+        return GrB_SUCCESS ;
+    }
+
+    new_capacity = *capacity ;
+    if (new_capacity == 0)
+    {
+        new_capacity = PATH_LIMIT ;
+        if (new_capacity == 0)
+        {
+            new_capacity = 1 ;
+        }
+    }
+
+    while (new_capacity < need)
+    {
+        if (new_capacity > SIZE_MAX / 2)
+        {
+            new_capacity = need ;
+            break ;
+        }
+
+        new_capacity = new_capacity * 2 ;
+    }
+
+    info = LAGraph_Malloc ((void **) &new_paths, new_capacity,
+        sizeof (Path), msg) ;
+    if (info != GrB_SUCCESS)
+    {
+        return info ;
+    }
+
+    memset (new_paths, 0, new_capacity * sizeof (Path)) ;
+
+    if (*paths != NULL)
+    {
+        memcpy (new_paths, *paths, (*capacity) * sizeof (Path)) ;
+        LAGraph_Free ((void **) paths, NULL) ;
+    }
+
+    *paths = new_paths ;
+    *capacity = new_capacity ;
+    return GrB_SUCCESS ;
+}
+
 
 #define LG_FREE_WORK                            \
 {                                               \
@@ -356,14 +1075,20 @@ void extend_multiple_trails_f(MultiplePaths *z, const MultiplePaths *x, GrB_Inde
     GrB_free (&symbol_frontier) ;               \
     GrB_free (&final_reducer) ;                 \
     LAGraph_Free ((void **) &A, NULL) ;         \
+    LAGraph_Free ((void **) &AT, NULL) ;        \
     LAGraph_Free ((void **) &B, NULL) ;         \
     LAGraph_Free ((void **) &BT, NULL) ;        \
+    LAGraph_Free ((void **) &X, NULL) ;         \
+    LAGraph_Free ((void **) &I, NULL) ;         \
+    temp_arena_destroy () ;                     \
 }
 
-#define LG_FREE_ALL                         \
-{                                           \
-    LG_FREE_WORK ;                          \
-    LAGraph_Free ((void **) paths, NULL) ;  \
+#define LG_FREE_ALL                             \
+{                                               \
+    LG_FREE_WORK ;                              \
+    free_all (paths, *path_count) ;             \
+    if (paths != NULL) *paths = NULL ;          \
+    if (path_count != NULL) *path_count = 0 ;   \
 }
 
 static int LAGraph_2Rpq
@@ -409,14 +1134,9 @@ static int LAGraph_2Rpq
 
     GrB_Index ng = 0 ;                   // # nodes in the graph
     GrB_Index nr = 0 ;                   // # states in the NFA
-    GrB_Index nv = 0 ;                   // # pair count in the frontier
-    GrB_Index states = ns ;              // # pairs in the current
-                                         // correspondence between the graph and
-                                         // the NFA
 
     GrB_Index rows = 0 ;                 // utility matrix row count
     GrB_Index cols = 0 ;                 // utility matrix column count
-    GrB_Index vals = 0 ;                 // utility matrix value count
 
     // TODO: This names might be too short.
     GrB_Semiring sr1 = first_combine_multiple_paths ;
@@ -428,15 +1148,23 @@ static int LAGraph_2Rpq
     GrB_Matrix *B = NULL ;
     GrB_Matrix *BT = NULL ;
 
-    LG_ASSERT (paths != NULL, GrB_NULL_POINTER) ;
-    LG_ASSERT (path_count != NULL, GrB_NULL_POINTER) ;
-    LG_ASSERT (G != NULL, GrB_NULL_POINTER) ;
-    LG_ASSERT (R != NULL, GrB_NULL_POINTER) ;
-    LG_ASSERT (S != NULL, GrB_NULL_POINTER) ;
-    LG_ASSERT (op != NULL, GrB_NULL_POINTER) ;
+    MultiplePaths *X = NULL ;
+    GrB_Index *I = NULL ;
+    size_t result_capacity = 0 ;
+
+    if (paths == NULL || path_count == NULL || G == NULL || R == NULL ||
+        S == NULL || op == NULL)
+    {
+        return GrB_NULL_POINTER ;
+    }
 
     (*paths) = NULL ;
     (*path_count) = 0 ;
+
+    path_limit_reset () ;
+
+    // init arenas for pathExtra
+    LG_TRY (temp_arena_init (msg)) ;
 
     for (size_t i = 0 ; i < nl ; i++)
     {
@@ -539,13 +1267,13 @@ static int LAGraph_2Rpq
     {
         if (B[i] == NULL) continue ;
 
-        GrB_Index rows = 0 ;
-        GrB_Index cols = 0 ;
+        GrB_Index rrows = 0 ;
+        GrB_Index rcols = 0 ;
 
-        GRB_TRY (GrB_Matrix_nrows (&rows, B[i])) ;
-        GRB_TRY (GrB_Matrix_ncols (&cols, B[i])) ;
+        GRB_TRY (GrB_Matrix_nrows (&rrows, B[i])) ;
+        GRB_TRY (GrB_Matrix_ncols (&rcols, B[i])) ;
 
-        LG_ASSERT_MSG (rows == nr && cols == nr, LAGRAPH_NOT_CACHED,
+        LG_ASSERT_MSG (rrows == nr && rcols == nr, LAGRAPH_NOT_CACHED,
             "all the matrices in the NFA adjacency matrix decomposition "
             "should have the same dimensions and be square") ;
     }
@@ -576,7 +1304,8 @@ static int LAGraph_2Rpq
     // initialization
     // -------------------------------------------------------------------------
 
-    LG_TRY (LAGraph_Calloc ((void **) paths, PATH_LIMIT, sizeof (Path), msg)) ;
+    GRB_TRY (LAGraph_Calloc ((void **) paths, PATH_LIMIT, sizeof (Path), msg)) ;
+    result_capacity = PATH_LIMIT ;
 
     GRB_TRY (GrB_Vector_new (&final_reducer, GrB_BOOL, nr)) ;
 
@@ -594,10 +1323,12 @@ static int LAGraph_2Rpq
             .paths = {
                 {
                     .vertices = { s },
-                    .vertex_count = 1
+                    .vertex_count = 1,
+                    .extra = NULL
                 }
             },
-            .path_count = 1
+            .path_count = 1,
+            .extra = NULL
         };
 
         for (size_t j = 0 ; j < nqs ; j++)
@@ -617,13 +1348,10 @@ static int LAGraph_2Rpq
     {
         //printf("Iteration\n");
         GrB_Index nvals = 0 ;
-        GRB_TRY (GrB_Matrix_nvals (&nvals, next_frontier)) ;
-
-        MultiplePaths *X ;
-        GrB_Index *I ;
         bool had_non_empty_path = false ;
 
-        //MultiplePaths *X;
+        GRB_TRY (GrB_Matrix_nvals (&nvals, next_frontier)) ;
+
         LG_TRY (LAGraph_Calloc ((void **) &X, nvals, sizeof (MultiplePaths), msg)) ;
         LG_TRY (LAGraph_Calloc ((void **) &I, nvals, sizeof (GrB_Index), msg)) ;
 
@@ -635,7 +1363,8 @@ static int LAGraph_2Rpq
         {
             for (size_t j = 0 ; j < X[i].path_count ; j++)
             {
-                if (!path_is_empty(&X[i].paths[j]))
+                // Required beacause we need to handle not only quick paths
+                if (!path_is_empty (multiple_paths_nth_const (&X[i], j)))
                 {
                     had_non_empty_path = true;
                     break;
@@ -660,15 +1389,33 @@ static int LAGraph_2Rpq
             }
 
             //printf("Found final paths!\n");
+            if ((*path_count) >= limit)
+            {
+                continue ;
+            }
+
+            size_t result_need = (*path_count) + X[i].path_count ;
+            if (result_need > result_capacity)
+            {
+                LG_TRY (ensure_result_capacity (paths, &result_capacity,
+                    result_need, msg)) ;
+            }
+
             for (size_t j = 0 ; j < X[i].path_count && (*path_count) < limit ; j++)
             {
-                const Path *path = &X[i].paths[j] ;
-                if (!path_is_empty(path))
+                // Deep copy of result
+                const Path *path = multiple_paths_nth_const (&X[i], j) ;
+                if (!path_is_empty (path))
                 {
-                    (*paths)[(*path_count)++] = *path ;
+                    LG_TRY (path_clone_heap (&((*paths)[(*path_count)]), path,
+                        msg)) ;
+                    (*path_count)++ ;
                 }
             }
         }
+
+        LAGraph_Free ((void **) &X, NULL) ;
+        LAGraph_Free ((void **) &I, NULL) ;
 
         if (!had_non_empty_path || (*path_count) == limit)
         {
@@ -704,7 +1451,10 @@ static int LAGraph_2Rpq
                 GRB_TRY (GrB_mxm (symbol_frontier, GrB_NULL, GrB_NULL, sr2, B[i], frontier, GrB_DESC_R )) ;
             }
 
-            // TODO: Skip the iteration if symbol_frontier is already empty.
+            // Skip the iteration if symbol_frontier is already empty.
+            GrB_Index symbol_nvals = 0 ;
+            GRB_TRY (GrB_Matrix_nvals (&symbol_nvals, symbol_frontier)) ;
+            if (symbol_nvals == 0) continue ;
 
             // Traverse the graph
             if (!inverse_labels[i]) {
@@ -724,18 +1474,26 @@ static int LAGraph_2Rpq
                     GRB_TRY (GrB_mxm (next_frontier, GrB_NULL, acc, sr1, symbol_frontier, A[i], GrB_NULL)) ;
                 }
             }
+
+            // Handle oom
+            LG_ASSERT_MSGF (!temp_alloc_failed (), GrB_OUT_OF_MEMORY,
+                "out of memory in temporary RPQ allocator: used=%zu capacity=%zu",
+                temp_arena_used (), temp_arena_capacity) ;
+            LG_ASSERT_MSG (!path_limit_failed (), GrB_OUT_OF_MEMORY,
+                "path limit per point exceeded") ;
         }
 
         GRB_TRY (GrB_apply (next_frontier, GrB_NULL, GrB_NULL, op, next_frontier, false, GrB_NULL)) ;
 
+        // Handle oom
+        LG_ASSERT_MSGF (!temp_alloc_failed (), GrB_OUT_OF_MEMORY,
+            "out of memory in temporary RPQ allocator: used=%zu capacity=%zu",
+            temp_arena_used (), temp_arena_capacity) ;
+        LG_ASSERT_MSG (!path_limit_failed (), GrB_OUT_OF_MEMORY,
+            "path limit per point exceeded") ;
     }
 
-    if (oom) {
-        // RODION, PLEASE HANDLE SOMEHOW
-    }
-
-    //LG_FREE_WORK ;
-    xfree();
+    LG_FREE_WORK ;
     return (GrB_SUCCESS) ;
 }
 
@@ -824,6 +1582,20 @@ int LAGraph_2Rpq_AllPaths       // All paths satisfying regular expression
         return LAGraph_2Rpq(paths, path_count, R, inverse_labels, nl, QS, nqs, QF, nqf, G, S, ns, inverse, limit, msg, extend_multiple_paths) ;
 }
 
+// Required because returned Path objects may own heap-allocated PathExtra.
+int LAGraph_2Rpq_FreePaths
+(
+    Path **paths,
+    size_t path_count,
+    char *msg
+)
+{
+    (void) msg ;
+
+    free_all (paths, path_count) ;
+    return GrB_SUCCESS ;
+}
+
 #define LG_FREE_WORK                            \
 {                                               \
 }
@@ -834,17 +1606,23 @@ int LAGraph_2Rpq_AllPaths       // All paths satisfying regular expression
 
 int LAGraph_Rpq_initialize(char *msg)
 {
-        GRB_TRY (GrB_Type_new (&multiple_paths, sizeof(MultiplePaths))) ;
+        (void) msg ;
 
-        GRB_TRY (GrB_BinaryOp_new (&combine_multiple_paths_op, (GxB_binary_function) &combine_multiple_paths_f, multiple_paths, multiple_paths, multiple_paths)) ;
-        GRB_TRY (GrB_BinaryOp_new (&first_multiple_paths, (GxB_binary_function) &first_multiple_paths_f, multiple_paths, multiple_paths, GrB_BOOL)) ;
-        GRB_TRY (GrB_BinaryOp_new (&second_multiple_paths, (GxB_binary_function) &second_multiple_paths_f, multiple_paths, GrB_BOOL, multiple_paths)) ;
+        memset (&multiple_paths_identity, 0, sizeof (multiple_paths_identity)) ;
+
+        GRB_TRY (GxB_Type_new (&multiple_paths, sizeof (MultiplePaths), "MultiplePaths", MULTIPLE_PATHS_TYPE_DEFN)) ;
+
+        GRB_TRY (GxB_BinaryOp_new (&combine_multiple_paths_op, (GxB_binary_function) &combine_multiple_paths_f, multiple_paths, multiple_paths, multiple_paths, "combine_multiple_paths_f", COMBINE_MULTIPLE_PATHS_DEFN)) ;
+        GRB_TRY (GxB_BinaryOp_new (&first_multiple_paths, (GxB_binary_function) &first_multiple_paths_f, multiple_paths, multiple_paths, GrB_BOOL, "first_multiple_paths_f", FIRST_MULTIPLE_PATHS_DEFN)) ;
+        GRB_TRY (GxB_BinaryOp_new (&second_multiple_paths, (GxB_binary_function) &second_multiple_paths_f, multiple_paths, GrB_BOOL, multiple_paths, "second_multiple_paths_f", SECOND_MULTIPLE_PATHS_DEFN)) ;
+
         GRB_TRY (GrB_Monoid_new (&combine_multiple_paths, combine_multiple_paths_op, (void*) &multiple_paths_identity)) ;
-
         GRB_TRY (GrB_Semiring_new (&first_combine_multiple_paths, combine_multiple_paths, first_multiple_paths)) ;
         GRB_TRY (GrB_Semiring_new (&second_combine_multiple_paths, combine_multiple_paths, second_multiple_paths)) ;
 
-        GRB_TRY (GrB_IndexUnaryOp_new (&extend_multiple_paths, (GxB_index_unary_function) &extend_multiple_paths_f, multiple_paths, multiple_paths, GrB_BOOL)) ;
-        GRB_TRY (GrB_IndexUnaryOp_new (&extend_multiple_simple, (GxB_index_unary_function) &extend_multiple_simple_f, multiple_paths, multiple_paths, GrB_BOOL)) ;
-        GRB_TRY (GrB_IndexUnaryOp_new (&extend_multiple_trails, (GxB_index_unary_function) &extend_multiple_trails_f, multiple_paths, multiple_paths, GrB_BOOL)) ;
+        GRB_TRY (GxB_IndexUnaryOp_new (&extend_multiple_paths, (GxB_index_unary_function) &extend_multiple_paths_f, multiple_paths, multiple_paths, GrB_BOOL, "extend_multiple_paths_f", EXTEND_MULTIPLE_PATHS_DEFN)) ;
+        GRB_TRY (GxB_IndexUnaryOp_new (&extend_multiple_simple, (GxB_index_unary_function) &extend_multiple_simple_f, multiple_paths, multiple_paths, GrB_BOOL, "extend_multiple_simple_f", EXTEND_MULTIPLE_SIMPLE_DEFN)) ;
+        GRB_TRY (GxB_IndexUnaryOp_new (&extend_multiple_trails, (GxB_index_unary_function) &extend_multiple_trails_f, multiple_paths, multiple_paths, GrB_BOOL, "extend_multiple_trails_f", EXTEND_MULTIPLE_TRAILS_DEFN)) ;
+
+        return GrB_SUCCESS ;
 }

--- a/experimental/algorithm/LAGraph_2Rpq.c
+++ b/experimental/algorithm/LAGraph_2Rpq.c
@@ -15,12 +15,44 @@
 #include <assert.h>
 #include <limits.h>
 
+
+#define MAX_MEM (1 * 1024 * 1024 * 1024)
+
+const char memory_arena[MAX_MEM];
+size_t cntr = 0;
+bool oom = false;
+void *xalloc(size_t size) {
+    assert(size % sizeof(int64_t) == 0);
+    if (cntr + size > MAX_MEM) {
+        // OOM: loop back to the beggining and flag the answer as wrong.
+        oom = true;
+        cntr = 0;
+    }
+
+    void *ptr = (void*) &(memory_arena[cntr]);
+    cntr += size;
+    return ptr;
+}
+void xfree(void) {
+#ifdef NDEBUG
+    printf("2RPQ arena allocator stats: allocated=%llu memory_limit=%llu\n", cntr, MAX_MEM);
+#endif
+    oom = false;
+    cntr = 0;
+}
+
+
 #define PATH_LIMIT 100000
+
+typedef struct MultiplePathsExtra {
+    size_t count;
+    Path paths[0];
+} MultiplePathsExtra;
 
 typedef struct {
     Path paths[QUICK_PATH_COUNT];
     size_t path_count;
-    Path *extra_paths;
+    MultiplePathsExtra *extra;
 } MultiplePaths ;
 
 MultiplePaths multiple_paths_identity ;
@@ -38,7 +70,7 @@ void Path_print (const Path *x)
         // Increase the vertex by 1 since usually user expects the same
         // numbering as in the input determined by MTX file in which the
         // entries are enumerated starting from 1.
-        printf ("(%ld)", (i < QUICK_PATH_LENGTH ? x->vertices[i] : x->extra_vertices[i - QUICK_PATH_LENGTH]) + 1) ;
+        printf ("(%llu)", (i < QUICK_PATH_LENGTH ? x->vertices[i] : x->extra->vertices[i - QUICK_PATH_LENGTH]) + 1) ;
 
         if (i != x->vertex_count - 1)
         {
@@ -81,23 +113,65 @@ void second_multiple_paths_f(MultiplePaths *z, bool *_x, MultiplePaths *y)
     *z = *y;
 }
 
+static inline MultiplePathsExtra *multiple_paths_extra_alloc(size_t count) {
+    MultiplePathsExtra *extra = xalloc(sizeof(MultiplePathsExtra) + count * sizeof(Path));
+    extra->count = count;
+    return extra;
+}
+
+#define nth_path(x, j) (((j) < QUICK_PATH_COUNT) ? ((x)->paths[j]) : ((x)->extra->paths[j - QUICK_PATH_COUNT]))
+#define set_nth_path(x, j, v) \
+    do { \
+        if (j < QUICK_PATH_COUNT) { \
+            x->paths[j] = v; \
+        } else { \
+            x->extra->paths[j - QUICK_PATH_COUNT] = v; \
+        } \
+    } while (0)
+
 void combine_multiple_paths_f(MultiplePaths *z, const MultiplePaths *x, const MultiplePaths *y)
 {
-    z->path_count = x->path_count + y->path_count ;
-    assert (z->path_count < QUICK_PATH_COUNT) ;
+    size_t path_count = x->path_count + y->path_count ;
+    z->path_count = path_count ;
 
-    for (size_t i = 0 ; i < x->path_count ; i++)
-    {
-        z->paths[i] = x->paths[i] ;
+
+    if (path_count <= QUICK_PATH_COUNT) {
+        size_t i = 0;
+        for (size_t j = 0 ; j < x->path_count ; j++)
+        {
+            z->paths[i++] = x->paths[j] ;
+        }
+
+        for (size_t j = 0 ; j < y->path_count ; j++)
+        {
+            z->paths[i++] = y->paths[j] ;
+        }
+        return;
+    } else {
+        MultiplePathsExtra *extra = multiple_paths_extra_alloc (path_count - QUICK_PATH_COUNT);
+        z->extra = extra;
+
+        size_t i = 0;
+        for (size_t j = 0 ; j < x->path_count ; j++)
+        {
+            Path path = nth_path(x, j);
+            set_nth_path(z, i, path);
+            i++;
+        }
+
+        for (size_t j = 0 ; j < y->path_count ; j++)
+        {
+            Path path = nth_path(y, j) ;
+            set_nth_path(z, i, path);
+            i++;
+        }
     }
 
-    for (size_t i = 0 ; i < y->path_count ; i++)
-    {
-        z->paths[x->path_count + i] = y->paths[i] ;
-    }
+
 
     // TODO: Support more than QUICK_PATH_COUNT paths.
 }
+
 
 static inline void path_extend(Path *path, Vertex vertex)
 {
@@ -112,11 +186,12 @@ static inline void path_extend(Path *path, Vertex vertex)
     }
     else
     {
-        if (path->extra_vertices == NULL)
+        if (path->extra == NULL)
         {
-            LG_TRY (LAGraph_Calloc ((void **) &path->extra_vertices, 64, sizeof (Vertex), NULL)) ;
+            LAGraph_Calloc ((void **) &path->extra, 64, sizeof (Vertex), NULL) ;
         }
-        path->extra_vertices [(path->vertex_count++) - QUICK_PATH_LENGTH] = vertex ;
+
+        path->extra->vertices [(path->vertex_count++) - QUICK_PATH_LENGTH] = vertex ;
     }
 
     // TODO: Support more than QUICK_PATH_LENGTH vertices.
@@ -655,7 +730,12 @@ static int LAGraph_2Rpq
 
     }
 
+    if (oom) {
+        // RODION, PLEASE HANDLE SOMEHOW
+    }
+
     //LG_FREE_WORK ;
+    xfree();
     return (GrB_SUCCESS) ;
 }
 

--- a/experimental/algorithm/LAGraph_2Rpq.c
+++ b/experimental/algorithm/LAGraph_2Rpq.c
@@ -1080,6 +1080,7 @@ static int ensure_result_capacity
     LAGraph_Free ((void **) &BT, NULL) ;        \
     LAGraph_Free ((void **) &X, NULL) ;         \
     LAGraph_Free ((void **) &I, NULL) ;         \
+    LAGraph_Free ((void **) &J, NULL) ;         \
     temp_arena_destroy () ;                     \
 }
 
@@ -1111,6 +1112,7 @@ static int LAGraph_2Rpq
     const GrB_Index *S,         // source vertices to start searching paths
     size_t ns,                  // number of source vertices
     bool inverse,               // inverse the whole query
+    bool ignore_visited,        // use mask to avoid processing the same (q, v)
     uint64_t limit,             // maximum path count
     char *msg,                  // LAGraph output message
     GrB_IndexUnaryOp op         // index unary op for a specific semantic
@@ -1129,6 +1131,7 @@ static int LAGraph_2Rpq
                                          // specific label
     GrB_Matrix next_frontier = NULL ;    // frontier value on the next
                                          // traversal step
+    GrB_Matrix visited = NULL ;          // visited pairs (state, vertex)
     GrB_Vector final_reducer = NULL ;    // auxiliary vector for reducing the
                                          // visited matrix to an answer
 
@@ -1150,6 +1153,7 @@ static int LAGraph_2Rpq
 
     MultiplePaths *X = NULL ;
     GrB_Index *I = NULL ;
+    GrB_Index *J = NULL ;
     size_t result_capacity = 0 ;
 
     if (paths == NULL || path_count == NULL || G == NULL || R == NULL ||
@@ -1314,6 +1318,11 @@ static int LAGraph_2Rpq
 
     GRB_TRY (GrB_Matrix_new (&next_frontier, multiple_paths, nr, ng)) ;
 
+    if (ignore_visited)
+    {
+        GRB_TRY (GrB_Matrix_new (&visited, GrB_BOOL, nr, ng)) ;
+    }
+
     // Initialize frontier with the source nodes
 
     for (size_t i = 0 ; i < ns ; i++)
@@ -1339,6 +1348,11 @@ static int LAGraph_2Rpq
         }
     }
 
+    if (ignore_visited)
+    {
+        GrB_assign (visited, NULL, NULL, true, QS, nqs, S, ns, NULL) ;
+    }
+
     // Initialize a few utility matrices
     GRB_TRY (GrB_Matrix_new (&frontier, multiple_paths, nr, ng)) ;
     GRB_TRY (GrB_Matrix_new (&symbol_frontier, multiple_paths, nr, ng)) ;
@@ -1354,9 +1368,10 @@ static int LAGraph_2Rpq
 
         LG_TRY (LAGraph_Calloc ((void **) &X, nvals, sizeof (MultiplePaths), msg)) ;
         LG_TRY (LAGraph_Calloc ((void **) &I, nvals, sizeof (GrB_Index), msg)) ;
+        LG_TRY (LAGraph_Calloc ((void **) &J, nvals, sizeof (GrB_Index), msg)) ;
 
         // TODO: Change to a generic call.
-        GRB_TRY (GrB_Matrix_extractTuples_UDT (I, GrB_NULL, (void**) X, &nvals, next_frontier)) ;
+        GRB_TRY (GrB_Matrix_extractTuples_UDT (I, J, (void**) X, &nvals, next_frontier)) ;
         //printf("Next frontier with %d entries\n", nvals);
 
         for (size_t i = 0 ; i < nvals ; i++)
@@ -1382,6 +1397,20 @@ static int LAGraph_2Rpq
                 }
             }
             //printf("Path at %ld final is %b", I[i], final) ;
+
+            // HACK: only for all_shortest_paths
+            if (ignore_visited) {
+                GrB_Vector w;
+                GRB_TRY (GrB_Vector_new (&w, GrB_BOOL, nr)) ;
+                GrB_Col_extract(w, GrB_NULL, GrB_NULL, visited, QF, nqf, J[i], GrB_NULL);
+                GrB_Index col_nvals = 0 ;
+                GrB_Vector_nvals (&col_nvals, w) ;
+                GrB_free (&w) ;
+
+                if (col_nvals > 0) {
+                    continue ;
+                }
+            }
 
             if (!final)
             {
@@ -1414,8 +1443,16 @@ static int LAGraph_2Rpq
             }
         }
 
+        if (ignore_visited)
+        {
+            //GRB_TRY (GrB_assign (visited, visited, GrB_NULL, next_frontier,
+            //    GrB_ALL, nr, GrB_ALL, ng, GrB_DESC_SC)) ;
+            GrB_assign (visited, next_frontier, GrB_NULL, true, GrB_ALL, nr, GrB_ALL, ng, GrB_DESC_S) ;
+        }
+
         LAGraph_Free ((void **) &X, NULL) ;
         LAGraph_Free ((void **) &I, NULL) ;
+        LAGraph_Free ((void **) &J, NULL) ;
 
         if (!had_non_empty_path || (*path_count) == limit)
         {
@@ -1456,22 +1493,25 @@ static int LAGraph_2Rpq
             GRB_TRY (GrB_Matrix_nvals (&symbol_nvals, symbol_frontier)) ;
             if (symbol_nvals == 0) continue ;
 
+            GrB_Descriptor desc_forward = ignore_visited ? GrB_DESC_SC : GrB_NULL ;
+            GrB_Descriptor desc_backward = ignore_visited ? GrB_DESC_SCT1 : GrB_DESC_T1 ;
+
             // Traverse the graph
             if (!inverse_labels[i]) {
                 if (!inverse) {
-                    GRB_TRY (GrB_mxm (next_frontier, GrB_NULL, acc, sr1, symbol_frontier, A[i], GrB_NULL)) ;
+                    GRB_TRY (GrB_mxm (next_frontier, visited, acc, sr1, symbol_frontier, A[i], desc_forward)) ;
                 } else if (AT[i]) {
-                    GRB_TRY (GrB_mxm (next_frontier, GrB_NULL, acc, sr1, symbol_frontier, AT[i], GrB_NULL)) ;
+                    GRB_TRY (GrB_mxm (next_frontier, visited, acc, sr1, symbol_frontier, AT[i], desc_forward)) ;
                 } else {
-                    GRB_TRY (GrB_mxm (next_frontier, GrB_NULL, acc, sr1, symbol_frontier, A[i], GrB_DESC_T1)) ;
+                    GRB_TRY (GrB_mxm (next_frontier, visited, acc, sr1, symbol_frontier, A[i], desc_backward)) ;
                 }
             } else {
                 if (!inverse && AT[i]) {
-                    GRB_TRY (GrB_mxm (next_frontier, GrB_NULL, acc, sr1, symbol_frontier, AT[i], GrB_NULL)) ;
+                    GRB_TRY (GrB_mxm (next_frontier, visited, acc, sr1, symbol_frontier, AT[i], desc_forward)) ;
                 } else if (!inverse) {
-                    GRB_TRY (GrB_mxm (next_frontier, GrB_NULL, acc, sr1, symbol_frontier, A[i], GrB_DESC_T1)) ;
+                    GRB_TRY (GrB_mxm (next_frontier, visited, acc, sr1, symbol_frontier, A[i], desc_backward)) ;
                 } else {
-                    GRB_TRY (GrB_mxm (next_frontier, GrB_NULL, acc, sr1, symbol_frontier, A[i], GrB_NULL)) ;
+                    GRB_TRY (GrB_mxm (next_frontier, visited, acc, sr1, symbol_frontier, A[i], desc_forward)) ;
                 }
             }
 
@@ -1524,7 +1564,7 @@ int LAGraph_2Rpq_AllSimple      // All simple paths satisfying regular
     char *msg                   // LAGraph output message
 )
 {
-    return LAGraph_2Rpq(paths, path_count, R, inverse_labels, nl, QS, nqs, QF, nqf, G, S, ns, inverse, ULLONG_MAX, msg, extend_multiple_simple) ;
+    return LAGraph_2Rpq(paths, path_count, R, inverse_labels, nl, QS, nqs, QF, nqf, G, S, ns, inverse, false, ULLONG_MAX, msg, extend_multiple_simple) ;
 }
 
 LAGRAPHX_PUBLIC
@@ -1552,7 +1592,7 @@ int LAGraph_2Rpq_AllTrails      // All trails satisfying regular expression.
     char *msg                   // LAGraph output message
 )
 {
-    return LAGraph_2Rpq(paths, path_count, R, inverse_labels, nl, QS, nqs, QF, nqf, G, S, ns, inverse, ULLONG_MAX, msg, extend_multiple_trails) ;
+    return LAGraph_2Rpq(paths, path_count, R, inverse_labels, nl, QS, nqs, QF, nqf, G, S, ns, inverse, false, ULLONG_MAX, msg, extend_multiple_trails) ;
 }
 
 int LAGraph_2Rpq_AllPaths       // All paths satisfying regular expression
@@ -1579,7 +1619,33 @@ int LAGraph_2Rpq_AllPaths       // All paths satisfying regular expression
     char *msg                   // LAGraph output message
     )
 {
-        return LAGraph_2Rpq(paths, path_count, R, inverse_labels, nl, QS, nqs, QF, nqf, G, S, ns, inverse, limit, msg, extend_multiple_paths) ;
+        return LAGraph_2Rpq(paths, path_count, R, inverse_labels, nl, QS, nqs, QF, nqf, G, S, ns, inverse, false, limit, msg, extend_multiple_paths) ;
+}
+
+int LAGraph_2Rpq_AllShortestPaths       // All shortest paths satisfying regular expression
+(
+    // output:
+    Path **paths,               // paths from one of the starting nodes
+                                // satisfying regular constraints
+    size_t *path_count,         // resulting path count
+                                // input:
+    LAGraph_Graph *R,           // input non-deterministic finite automaton
+                                // adjacency matrix decomposition
+    bool *inverse_labels,       // inversed labels
+    size_t nl,                  // total label count, # of matrices graph and
+                                // NFA adjacency matrix decomposition
+    const GrB_Index *QS,        // starting states in NFA
+    size_t nqs,                 // number of starting states in NFA
+    const GrB_Index *QF,        // final states in NFA
+    size_t nqf,                 // number of final states in NFA
+    LAGraph_Graph *G,           // input graph adjacency matrix decomposition
+    const GrB_Index *S,         // source vertices to start searching paths
+    size_t ns,                  // number of source vertices
+    bool inverse,               // inverse the whole query
+    char *msg                   // LAGraph output message
+    )
+{
+        return LAGraph_2Rpq(paths, path_count, R, inverse_labels, nl, QS, nqs, QF, nqf, G, S, ns, inverse, true, ULLONG_MAX, msg, extend_multiple_paths) ;
 }
 
 // Required because returned Path objects may own heap-allocated PathExtra.

--- a/experimental/algorithm/LAGraph_RegularPathQuery.c
+++ b/experimental/algorithm/LAGraph_RegularPathQuery.c
@@ -255,7 +255,11 @@ int LAGraph_RegularPathQuery
     }
 
     // Check source nodes in the graph
+<<<<<<< HEAD
     for (size_t i = 0 ; i < ns ; i++)
+=======
+    for (GrB_Index i = 0; i < ns; i++)
+>>>>>>> 30e086c8 (Add regular path query algorithm)
     {
         GrB_Index s = S [i] ;
         LG_ASSERT_MSG (s < ng, GrB_INVALID_INDEX, "invalid graph source node") ;

--- a/experimental/test/test_2Rpq.c
+++ b/experimental/test/test_2Rpq.c
@@ -1,0 +1,249 @@
+#include <stdio.h>
+#include <acutest.h>
+#include <LG_Xtest.h>
+#include <LG_test.h>
+#include <LAGraphX.h>
+#include <LAGraph_test.h>
+
+#define LEN 512
+#define MAX_LABELS 3
+#define MAX_RESULTS 2000000
+
+char msg [LAGRAPH_MSG_LEN] ;
+LAGraph_Graph G[MAX_LABELS] ;
+LAGraph_Graph R[MAX_LABELS] ;
+GrB_Matrix A ;
+
+char testcase_name [LEN+1] ;
+char filename [LEN+1] ;
+
+typedef struct
+{
+    const char* name ;
+    const char* graphs[MAX_LABELS] ;
+    const char* fas[MAX_LABELS] ;
+    const char* fa_meta ;
+    const char* sources ;
+    const GrB_Index expected[MAX_RESULTS] ;
+    const size_t expected_count ;
+}
+matrix_info ;
+
+const matrix_info files [ ] =
+{
+    {"simple 1 or more",
+     {"rpq_data/a.mtx",   "rpq_data/b.mtx",   NULL},
+     {"rpq_data/1_a.mtx", NULL },                    // Regex: a+
+     "rpq_data/1_meta.txt",
+     "rpq_data/1_sources.txt",
+     {2, 4, 6, 7}, 4},
+    {"simple kleene star",
+     {"rpq_data/a.mtx",   "rpq_data/b.mtx",   NULL},
+     {"rpq_data/2_a.mtx", "rpq_data/2_b.mtx", NULL}, // Regex: (a b)*
+     "rpq_data/2_meta.txt",
+     "rpq_data/2_sources.txt",
+     {2, 6, 8}, 3},
+    {"kleene star of the conjunction",
+     {"rpq_data/a.mtx",   "rpq_data/b.mtx",   NULL},
+     {"rpq_data/3_a.mtx", "rpq_data/3_b.mtx", NULL}, // Regex: (a | b)*
+     "rpq_data/3_meta.txt",
+     "rpq_data/3_sources.txt",
+     {3, 6}, 2},
+    {"simple repeat from n to m times",
+     {"rpq_data/a.mtx",   "rpq_data/b.mtx",   NULL},
+     {"",                 "rpq_data/4_b.mtx", NULL}, // Regex: b b b (b b)?
+     "rpq_data/4_meta.txt",
+     "rpq_data/4_sources.txt",
+     {3, 4, 6}, 3},
+    {NULL, NULL, NULL, NULL},
+} ;
+
+//****************************************************************************
+void test_Rpq_Simple (void)
+{
+    LAGraph_Init (msg) ;
+    LAGraph_Rpq_initialize (msg) ;
+
+    for (int k = 0 ; ; k++)
+    {
+        if (files[k].sources == NULL) break ;
+
+        snprintf (testcase_name, LEN, "basic regular path query %s", files[k].name) ;
+        TEST_CASE (testcase_name) ;
+
+        // Load graph from MTX files representing its adjacency matrix
+        // decomposition
+        for (int i = 0 ; ; i++)
+        {
+            const char *name = files[k].graphs[i] ;
+
+            if (name == NULL) break ;
+            if (strlen(name) == 0) continue ;
+
+            snprintf (filename, LEN, LG_DATA_DIR "%s", name) ;
+            FILE *f = fopen (filename, "r") ;
+            TEST_CHECK (f != NULL) ;
+            OK (LAGraph_MMRead (&A, f, msg)) ;
+            OK (fclose (f));
+
+            OK (LAGraph_New (&(G[i]), &A, LAGraph_ADJACENCY_DIRECTED, msg)) ;
+
+            TEST_CHECK (A == NULL) ;
+        }
+
+        // Load NFA from MTX files representing its adjacency matrix
+        // decomposition
+        for (int i = 0 ; ; i++)
+        {
+            const char *name = files[k].fas[i] ;
+
+            if (name == NULL) break ;
+            if (strlen(name) == 0) continue ;
+
+            snprintf (filename, LEN, LG_DATA_DIR "%s", name) ;
+            FILE *f = fopen (filename, "r") ;
+            TEST_CHECK (f != NULL) ;
+            OK (LAGraph_MMRead (&A, f, msg)) ;
+            OK (fclose (f)) ;
+
+            OK (LAGraph_New (&(R[i]), &A, LAGraph_ADJACENCY_DIRECTED, msg)) ;
+            OK (LAGraph_Cached_AT (R[i], msg)) ;
+
+            TEST_CHECK (A == NULL) ;
+        }
+
+        // Note the matrix rows/cols are enumerated from 0 to n-1. Meanwhile, in
+        // MTX format they are enumerated from 1 to n. Thus, when
+        // loading/comparing the results these values should be
+        // decremented/incremented correspondingly.
+
+        // Load graph source nodes from the sources file
+        GrB_Index s ;
+        GrB_Index S[16] ;
+        size_t ns = 0 ;
+
+        const char *name = files[k].sources ;
+        snprintf (filename, LEN, LG_DATA_DIR "%s", name) ;
+        FILE *f = fopen (filename, "r") ;
+        TEST_CHECK (f != NULL) ;
+
+        while (fscanf(f, "%ld", &s) != EOF)
+            S[ns++] = s - 1 ;
+
+        OK (fclose(f)) ;
+
+        // Load NFA starting states from the meta file
+        GrB_Index qs ;
+        GrB_Index QS[16] ;
+        size_t nqs = 0 ;
+
+        name = files[k].fa_meta ;
+        snprintf (filename, LEN, LG_DATA_DIR "%s", name) ;
+        f = fopen (filename, "r") ;
+        TEST_CHECK (f != NULL) ;
+
+        TEST_CHECK (fscanf(f, "%ld", &nqs) != EOF) ;
+
+        for (uint64_t i = 0; i < nqs; i++) {
+            TEST_CHECK (fscanf(f, "%ld", &qs) != EOF) ;
+            QS[i] = qs - 1 ;
+        }
+
+        // Load NFA final states from the same file
+        uint64_t qf ;
+        uint64_t QF[16] ;
+        size_t nqf = 0 ;
+
+        TEST_CHECK (fscanf(f, "%ld", &nqf) != EOF) ;
+
+        for (uint64_t i = 0; i < nqf; i++) {
+            TEST_CHECK (fscanf(f, "%ld", &qf) != EOF) ;
+            QF[i] = qf - 1 ;
+        }
+
+        OK (fclose(f)) ;
+
+        // Evaluate the algorithm
+        GrB_Vector r = NULL ;
+
+        bool inverse_labels[] = {false, false, false, false, false, false, false, false, false, false, false, false, false};
+        bool inverse = false;
+
+        Path *paths ;
+        size_t path_count ;
+        int res = LAGraph_2Rpq_AllSimple (&paths, &path_count, R, inverse_labels,
+                                    MAX_LABELS, QS, nqs, QF, nqf, G, S, ns,
+                                    inverse, msg) ;
+
+        // Compare the results with expected values
+        //TEST_CHECK (nvals == files[k].expected_count) ;
+        //for (uint64_t i = 0 ; i < nvals ; i++)
+        //    TEST_CHECK (reachable[i] + 1 == files[k].expected[i]) ;
+
+        printf("ALL SIMPLE:\n");
+        for (size_t i = 0 ; i < path_count ; i++)
+        {
+            Path_print (&paths[i]);
+        }
+        printf("\n");
+
+        // Cleanup
+        OK (LAGraph_Free ((void **) &paths, NULL)) ;
+
+        res = LAGraph_2Rpq_AllTrails (&paths, &path_count, R, inverse_labels,
+                                    MAX_LABELS, QS, nqs, QF, nqf, G, S, ns,
+                                    inverse, msg) ;
+
+        // Compare the results with expected values
+        //TEST_CHECK (nvals == files[k].expected_count) ;
+        //for (uint64_t i = 0 ; i < nvals ; i++)
+        //    TEST_CHECK (reachable[i] + 1 == files[k].expected[i]) ;
+
+        printf("ALL TRAILS:\n");
+        for (size_t i = 0 ; i < path_count ; i++)
+        {
+            Path_print (&paths[i]);
+        }
+        printf("\n");
+
+        // Cleanup
+        OK (LAGraph_Free ((void **) &paths, NULL)) ;
+
+        res = LAGraph_2Rpq_AllPaths (&paths, &path_count, R, inverse_labels,
+                                    MAX_LABELS, QS, nqs, QF, nqf, G, S, ns,
+                                    inverse, 10, msg) ;
+
+        // Compare the results with expected values
+        //TEST_CHECK (nvals == files[k].expected_count) ;
+        //for (uint64_t i = 0 ; i < nvals ; i++)
+        //    TEST_CHECK (reachable[i] + 1 == files[k].expected[i]) ;
+
+        printf("ALL PATHS (LIMIT = 10):\n");
+        for (size_t i = 0 ; i < path_count ; i++)
+        {
+            Path_print (&paths[i]);
+        }
+        printf("\n");
+
+        OK (LAGraph_Free ((void **) &paths, NULL)) ;
+
+        for (uint64_t i = 0 ; i < MAX_LABELS ; i++)
+        {
+            if (G[i] == NULL) continue ;
+            OK (LAGraph_Delete (&(G[i]), msg)) ;
+        }
+
+        for (uint64_t i = 0 ; i < MAX_LABELS ; i++ )
+        {
+            if (R[i] == NULL) continue ;
+            OK (LAGraph_Delete (&(R[i]), msg)) ;
+        }
+    }
+
+    LAGraph_Finalize (msg) ;
+}
+
+TEST_LIST = {
+    {"Rpq_Simple", test_Rpq_Simple},
+    {NULL, NULL}
+};

--- a/experimental/test/test_2Rpq.c
+++ b/experimental/test/test_2Rpq.c
@@ -230,7 +230,7 @@ void test_Rpq_Simple (void)
 
         res = LAGraph_2Rpq_AllShortestPaths (&paths, &path_count, R, inverse_labels,
                                             MAX_LABELS, QS, nqs, QF, nqf, G, S, ns,
-                                            inverse, msg) ;
+                                            inverse, 100, msg) ;
 
         // Compare the results with expected values
         //TEST_CHECK (nvals == files[k].expected_count) ;

--- a/experimental/test/test_2Rpq.c
+++ b/experimental/test/test_2Rpq.c
@@ -225,6 +225,26 @@ void test_Rpq_Simple (void)
         }
         printf("\n");
 
+        // Cleanup
+        OK (LAGraph_Free ((void **) &paths, NULL)) ;
+
+        res = LAGraph_2Rpq_AllShortestPaths (&paths, &path_count, R, inverse_labels,
+                                            MAX_LABELS, QS, nqs, QF, nqf, G, S, ns,
+                                            inverse, msg) ;
+
+        // Compare the results with expected values
+        //TEST_CHECK (nvals == files[k].expected_count) ;
+        //for (uint64_t i = 0 ; i < nvals ; i++)
+        //    TEST_CHECK (reachable[i] + 1 == files[k].expected[i]) ;
+
+        printf("ALL SHORTEST PATHS:\n");
+        for (size_t i = 0 ; i < path_count ; i++)
+        {
+            Path_print (&paths[i]);
+        }
+        printf("\n");
+
+        // Cleanup
         OK (LAGraph_Free ((void **) &paths, NULL)) ;
 
         for (uint64_t i = 0 ; i < MAX_LABELS ; i++)

--- a/experimental/test/test_RegularPathQuery.c
+++ b/experimental/test/test_RegularPathQuery.c
@@ -178,8 +178,9 @@ void test_RegularPathQueryBasic (void)
 
             // Evaluate the algorithm
             GrB_Vector r = NULL ;
+            bool inverse_labels[MAX_LABELS] = {false} ;
 
-            OK (LAGraph_2RegularPathQuery (&r, R, false, MAX_LABELS, QS, nqs,
+            OK (LAGraph_2RegularPathQuery (&r, R, inverse_labels, MAX_LABELS, QS, nqs,
                                              QF, nqf, G, S, ns, false, msg)) ;
 
             // Extract results from the output vector
@@ -190,7 +191,7 @@ void test_RegularPathQueryBasic (void)
             GrB_Vector_nvals (&nvals, r) ;
 
             OK (LAGraph_Malloc ((void **) &reachable, MAX_RESULTS, sizeof (GrB_Index), msg)) ;
-            OK (LAGraph_Malloc ((void **) &values, MAX_RESULTS, sizeof (GrB_Index), msg)) ;
+            OK (LAGraph_Malloc ((void **) &values, MAX_RESULTS, sizeof (bool), msg)) ;
 
             GrB_Vector_extractTuples (reachable, values, &nvals, r) ;
 
@@ -211,43 +212,11 @@ void test_RegularPathQueryBasic (void)
                 OK (LAGraph_Delete (&(G[i]), msg)) ;
             }
 
-        // TODO: Use 2RPQ HERE.
-        //OK (LAGraph_RegularPathQuery (&r, R, MAX_LABELS, QS, nqs,
-        //                                  QF, nqf, G, S, ns, msg)) ;
-
-        // Extract results from the output vector
-        GrB_Index *reachable ;
-        bool *values ;
-
-        GrB_Index nvals ;
-        GrB_Vector_nvals (&nvals, r) ;
-
-        OK (LAGraph_Malloc ((void **) &reachable, MAX_RESULTS, sizeof (GrB_Index), msg)) ;
-        OK (LAGraph_Malloc ((void **) &values, MAX_RESULTS, sizeof (GrB_Index), msg)) ;
-
-        GrB_Vector_extractTuples (reachable, values, &nvals, r) ;
-
-        // Compare the results with expected values
-        TEST_CHECK (nvals == files[k].expected_count) ;
-        for (uint64_t i = 0 ; i < nvals ; i++)
-            TEST_CHECK (reachable[i] + 1 == files[k].expected[i]) ;
-
-        // Cleanup
-        OK (LAGraph_Free ((void **) &values, NULL)) ;
-        OK (LAGraph_Free ((void **) &reachable, NULL)) ;
-
-        OK (GrB_free (&r)) ;
-
-        for (uint64_t i = 0 ; i < MAX_LABELS ; i++)
-        {
-            if (G[i] == NULL) continue ;
-            OK (LAGraph_Delete (&(G[i]), msg)) ;
-        }
-
-        for (uint64_t i = 0 ; i < MAX_LABELS ; i++ )
-        {
-            if (R[i] == NULL) continue ;
-            OK (LAGraph_Delete (&(R[i]), msg)) ;
+            for (uint64_t i = 0 ; i < MAX_LABELS ; i++ )
+            {
+                if (R[i] == NULL) continue ;
+                OK (LAGraph_Delete (&(R[i]), msg)) ;
+            }
         }
     }
 

--- a/experimental/test/test_RegularPathQuery.c
+++ b/experimental/test/test_RegularPathQuery.c
@@ -211,11 +211,43 @@ void test_RegularPathQueryBasic (void)
                 OK (LAGraph_Delete (&(G[i]), msg)) ;
             }
 
-            for (uint64_t i = 0 ; i < MAX_LABELS ; i++ )
-            {
-                if (R[i] == NULL) continue ;
-                OK (LAGraph_Delete (&(R[i]), msg)) ;
-            }
+        // TODO: Use 2RPQ HERE.
+        //OK (LAGraph_RegularPathQuery (&r, R, MAX_LABELS, QS, nqs,
+        //                                  QF, nqf, G, S, ns, msg)) ;
+
+        // Extract results from the output vector
+        GrB_Index *reachable ;
+        bool *values ;
+
+        GrB_Index nvals ;
+        GrB_Vector_nvals (&nvals, r) ;
+
+        OK (LAGraph_Malloc ((void **) &reachable, MAX_RESULTS, sizeof (GrB_Index), msg)) ;
+        OK (LAGraph_Malloc ((void **) &values, MAX_RESULTS, sizeof (GrB_Index), msg)) ;
+
+        GrB_Vector_extractTuples (reachable, values, &nvals, r) ;
+
+        // Compare the results with expected values
+        TEST_CHECK (nvals == files[k].expected_count) ;
+        for (uint64_t i = 0 ; i < nvals ; i++)
+            TEST_CHECK (reachable[i] + 1 == files[k].expected[i]) ;
+
+        // Cleanup
+        OK (LAGraph_Free ((void **) &values, NULL)) ;
+        OK (LAGraph_Free ((void **) &reachable, NULL)) ;
+
+        OK (GrB_free (&r)) ;
+
+        for (uint64_t i = 0 ; i < MAX_LABELS ; i++)
+        {
+            if (G[i] == NULL) continue ;
+            OK (LAGraph_Delete (&(G[i]), msg)) ;
+        }
+
+        for (uint64_t i = 0 ; i < MAX_LABELS ; i++ )
+        {
+            if (R[i] == NULL) continue ;
+            OK (LAGraph_Delete (&(R[i]), msg)) ;
         }
     }
 

--- a/experimental/test/test_RegularPathQuery.c
+++ b/experimental/test/test_RegularPathQuery.c
@@ -179,8 +179,8 @@ void test_RegularPathQueryBasic (void)
             // Evaluate the algorithm
             GrB_Vector r = NULL ;
 
-            OK (LAGraph_RegularPathQuery (&r, R, MAX_LABELS, QS, nqs,
-                                             QF, nqf, G, S, ns, msg)) ;
+            OK (LAGraph_2RegularPathQuery (&r, R, false, MAX_LABELS, QS, nqs,
+                                             QF, nqf, G, S, ns, false, msg)) ;
 
             // Extract results from the output vector
             GrB_Index *reachable ;

--- a/include/LAGraphX.h
+++ b/include/LAGraphX.h
@@ -858,15 +858,20 @@ int LAGraph_2RegularPathQuery   // nodes reachable from the starting by the
     char *msg                   // LAGraph output message
 );
 //****************************************************************************
-#define QUICK_PATH_LENGTH 14
-#define QUICK_PATH_COUNT 2
+#define QUICK_PATH_LENGTH 20
+#define QUICK_PATH_COUNT 1
 
 typedef uint64_t Vertex ;
+
+typedef struct PathExtra {
+    size_t len;
+    Vertex vertices[0];
+} PathExtra ;
 
 typedef struct {
         Vertex vertices[QUICK_PATH_LENGTH];
         size_t vertex_count;
-        Vertex *extra_vertices;
+        PathExtra *extra;
 } Path ;
 
 void Path_print (const Path *x);

--- a/include/LAGraphX.h
+++ b/include/LAGraphX.h
@@ -885,8 +885,7 @@ int LAGraph_Rpq_initialize (char *msg);
 LAGRAPHX_PUBLIC
 int LAGraph_2Rpq_AllSimple      // All simple paths satisfying regular
                                 // expression. Simple paths are paths without
-                                // loops or the ones with the same starting
-                                // and final nodes.
+                                // repeated vertices.
 (
     // output:
     Path **paths,               // simple paths from one of the starting
@@ -980,6 +979,7 @@ int LAGraph_2Rpq_AllShortestPaths // All shortest paths satisfying regular expre
     const GrB_Index *S,         // source vertices to start searching paths
     size_t ns,                  // number of source vertices
     bool inverse,               // inverse the whole query
+    uint64_t limit,             // maximum path count
     char *msg                   // LAGraph output message
 );
 //****************************************************************************

--- a/include/LAGraphX.h
+++ b/include/LAGraphX.h
@@ -874,6 +874,9 @@ typedef struct {
         PathExtra *extra;
 } Path ;
 
+LAGRAPHX_PUBLIC
+int LAGraph_2Rpq_FreePaths(Path **paths, size_t path_count, char *msg);
+
 void Path_print (const Path *x);
 
 LAGRAPHX_PUBLIC

--- a/include/LAGraphX.h
+++ b/include/LAGraphX.h
@@ -858,6 +858,99 @@ int LAGraph_2RegularPathQuery   // nodes reachable from the starting by the
     char *msg                   // LAGraph output message
 );
 //****************************************************************************
+#define QUICK_PATH_LENGTH 14
+#define QUICK_PATH_COUNT 2
+
+typedef uint64_t Vertex ;
+
+typedef struct {
+        Vertex vertices[QUICK_PATH_LENGTH];
+        size_t vertex_count;
+        Vertex *extra_vertices;
+} Path ;
+
+void Path_print (const Path *x);
+
+LAGRAPHX_PUBLIC
+int LAGraph_Rpq_initialize (char *msg);
+
+LAGRAPHX_PUBLIC
+int LAGraph_2Rpq_AllSimple      // All simple paths satisfying regular
+                                // expression. Simple paths are paths without
+                                // loops or the ones with the same starting
+                                // and final nodes.
+(
+    // output:
+    Path **paths,               // simple paths from one of the starting
+                                // nodes satisfying regular constraints
+    size_t *path_count,         // resulting path count
+    // input:
+    LAGraph_Graph *R,           // input non-deterministic finite automaton
+                                // adjacency matrix decomposition
+    bool *inverse_labels,       // inversed labels
+    size_t nl,                  // total label count, # of matrices graph and
+                                // NFA adjacency matrix decomposition
+    const GrB_Index *QS,        // starting states in NFA
+    size_t nqs,                 // number of starting states in NFA
+    const GrB_Index *QF,        // final states in NFA
+    size_t nqf,                 // number of final states in NFA
+    LAGraph_Graph *G,           // input graph adjacency matrix decomposition
+    const GrB_Index *S,         // source vertices to start searching paths
+    size_t ns,                  // number of source vertices
+    bool inverse,               // inverse the whole query
+    char *msg                   // LAGraph output message
+);
+
+LAGRAPHX_PUBLIC
+int LAGraph_2Rpq_AllTrails      // All trails satisfying regular expression.
+                                // Trails are paths without repeated edges.
+(
+    // output:
+    Path **paths,               // trails from one of the starting nodes
+                                // satisfying regular constraints
+    size_t *path_count,         // resulting path count
+    // input:
+    LAGraph_Graph *R,           // input non-deterministic finite automaton
+                                // adjacency matrix decomposition
+    bool *inverse_labels,       // inversed labels
+    size_t nl,                  // total label count, # of matrices graph and
+                                // NFA adjacency matrix decomposition
+    const GrB_Index *QS,        // starting states in NFA
+    size_t nqs,                 // number of starting states in NFA
+    const GrB_Index *QF,        // final states in NFA
+    size_t nqf,                 // number of final states in NFA
+    LAGraph_Graph *G,           // input graph adjacency matrix decomposition
+    const GrB_Index *S,         // source vertices to start searching paths
+    size_t ns,                  // number of source vertices
+    bool inverse,               // inverse the whole query
+    char *msg                   // LAGraph output message
+);
+
+LAGRAPHX_PUBLIC
+int LAGraph_2Rpq_AllPaths       // All paths satisfying regular expression
+(
+    // output:
+    Path **paths,               // paths from one of the starting nodes
+                                // satisfying regular constraints
+    size_t *path_count,         // resulting path count
+    // input:
+    LAGraph_Graph *R,           // input non-deterministic finite automaton
+                                // adjacency matrix decomposition
+    bool *inverse_labels,       // inversed labels
+    size_t nl,                  // total label count, # of matrices graph and
+                                // NFA adjacency matrix decomposition
+    const GrB_Index *QS,        // starting states in NFA
+    size_t nqs,                 // number of starting states in NFA
+    const GrB_Index *QF,        // final states in NFA
+    size_t nqf,                 // number of final states in NFA
+    LAGraph_Graph *G,           // input graph adjacency matrix decomposition
+    const GrB_Index *S,         // source vertices to start searching paths
+    size_t ns,                  // number of source vertices
+    bool inverse,               // inverse the whole query
+    uint64_t limit,             // maximum path count
+    char *msg                   // LAGraph output message
+);
+//****************************************************************************
 LAGRAPHX_PUBLIC
 int LAGraph_VertexCentrality_Triangle       // vertex triangle-centrality
 (

--- a/include/LAGraphX.h
+++ b/include/LAGraphX.h
@@ -958,6 +958,30 @@ int LAGraph_2Rpq_AllPaths       // All paths satisfying regular expression
     uint64_t limit,             // maximum path count
     char *msg                   // LAGraph output message
 );
+
+LAGRAPHX_PUBLIC
+int LAGraph_2Rpq_AllShortestPaths // All shortest paths satisfying regular expression
+(
+    // output:
+    Path **paths,               // paths from one of the starting nodes
+                                // satisfying regular constraints
+    size_t *path_count,         // resulting path count
+    // input:
+    LAGraph_Graph *R,           // input non-deterministic finite automaton
+                                // adjacency matrix decomposition
+    bool *inverse_labels,       // inversed labels
+    size_t nl,                  // total label count, # of matrices graph and
+                                // NFA adjacency matrix decomposition
+    const GrB_Index *QS,        // starting states in NFA
+    size_t nqs,                 // number of starting states in NFA
+    const GrB_Index *QF,        // final states in NFA
+    size_t nqf,                 // number of final states in NFA
+    LAGraph_Graph *G,           // input graph adjacency matrix decomposition
+    const GrB_Index *S,         // source vertices to start searching paths
+    size_t ns,                  // number of source vertices
+    bool inverse,               // inverse the whole query
+    char *msg                   // LAGraph output message
+);
 //****************************************************************************
 LAGRAPHX_PUBLIC
 int LAGraph_VertexCentrality_Triangle       // vertex triangle-centrality

--- a/include/LAGraphX.h
+++ b/include/LAGraphX.h
@@ -834,7 +834,7 @@ int LAGraph_scc (
 
 //****************************************************************************
 LAGRAPHX_PUBLIC
-int LAGraph_RegularPathQuery    // nodes reachable from the starting by the
+int LAGraph_2RegularPathQuery   // nodes reachable from the starting by the
                                 // path satisfying regular expression
 (
     // output:
@@ -844,6 +844,7 @@ int LAGraph_RegularPathQuery    // nodes reachable from the starting by the
     // input:
     LAGraph_Graph *R,           // input non-deterministic finite automaton
                                 // adjacency matrix decomposition
+    bool *inverse_labels,       // inversed labels
     size_t nl,                  // total label count, # of matrices graph and
                                 // NFA adjacency matrix decomposition
     const GrB_Index *QS,        // starting states in NFA
@@ -853,6 +854,7 @@ int LAGraph_RegularPathQuery    // nodes reachable from the starting by the
     LAGraph_Graph *G,           // input graph adjacency matrix decomposition
     const GrB_Index *S,         // source vertices to start searching paths
     size_t ns,                  // number of source vertices
+    bool inverse,               // inverse the whole query
     char *msg                   // LAGraph output message
 );
 //****************************************************************************

--- a/src/utility/LAGraph_MMRead.c
+++ b/src/utility/LAGraph_MMRead.c
@@ -989,7 +989,7 @@ int LAGraph_MMRead
 
     if (type == GrB_BOOL)
     {
-        GRB_TRY (GrB_Matrix_build_BOOL (*A, I, J, (bool *) X, nvals2, NULL)) ;
+        GRB_TRY (GrB_Matrix_build_BOOL (*A, I, J, (bool *) X, nvals2, GxB_IGNORE_DUP)) ;
     }
     else if (type == GrB_INT8)
     {


### PR DESCRIPTION
# Algorithm for Evaluating 2-RPQ Queries with Path Storing

This PR introduces an algorithm for evaluating 2-RPQ queries with path storing.

The algorithm supports three path semantics:

1. `ALL-SHORTEST-PATHS`
2. `ALL-SIMPLE-PATHS`
3. `ALL-TRAILS`

These semantics correspond to the path semantics used in the
[MillenniumDB Path Query Challenge](https://ceur-ws.org/Vol-3409/paper13.pdf).

## Algorithm idea

The algorithm is based on the standard linear-algebra approach for evaluating
RPQ. In the classical version, RPQ evaluation is reduced to
reachability computation over Boolean matrices: graph labels are represented as
adjacency matrices, the query is represented as a finite automaton, and matrix
operations propagate reachable graph/automaton states.

This PR generalizes that approach by replacing the Boolean semiring with custom
path semirings. Instead of storing only whether a state is reachable, matrix
elements store path information. Semiring operations define how paths are
extended, combined, and filtered according to the selected semantics.

In particular:

- multiplication extends existing paths with graph edges;
- addition merges alternative paths reaching the same state;
- semantic-specific checks reject invalid path extensions:
  - repeated vertices are forbidden for `ALL-SIMPLE-PATHS`;
  - repeated edges are forbidden for `ALL-TRAILS`;
  - only shortest paths are preserved for `ALL-SHORTEST-PATHS`.

As a result, the Boolean reachability algorithm can be seen as a special case of
the same framework, while path-producing semantics are implemented by changing
the underlying semiring.
One step of algorithm with `ALL-SIMPLE` semantic are provided on following figure:
<img width="1292" height="914" alt="image" src="https://github.com/user-attachments/assets/b54c2abd-333c-4893-a748-df7bb36bd313" />


## Memory management

Path-storing evaluation may create a large number of intermediate path objects.
To reduce allocation overhead, the implementation uses a custom allocator for
path data structures. The allocator centralizes ownership of intermediate path
objects and allows the algorithm to allocate paths efficiently during semiring
operations, instead of relying on many small heap allocations. Also this approach provide 
the opportunity to work with variable-size object using custom structures in GraphBLAS
primitives which size must be constant.
